### PR TITLE
Include reasoning content in message formatting

### DIFF
--- a/src/vita/utils/llm_utils.py
+++ b/src/vita/utils/llm_utils.py
@@ -99,6 +99,11 @@ def format_messages(messages: list[Message]) -> list[dict]:
                     "tool_calls": tool_calls,
                 }
             )
+            # add interleaved thinking content if exists
+            if message.raw_data is not None and message.raw_data.get("message") is not None:
+                reasoning_content = message.raw_data["message"].get("reasoning_content")
+                if reasoning_content:
+                    messages_formatted[-1]["reasoning_content"] = reasoning_content
         elif isinstance(message, ToolMessage):
             messages_formatted.append(
                 {


### PR DESCRIPTION
Add support for including reasoning content in formatted messages when available.  

This is essential for models with thinking capabilities (e.g., `deepseek-v3.2-thinking`, `kimi-k2-thinking`, `minimax-m2`, `qwen3-thinking`, etc.) to evaluate their full performance. Thanks for considering!