### PR TITLE
Fix a bug  caused by duplicate values in products

### DIFF
--- a/src/vita/utils/utils.py
+++ b/src/vita/utils/utils.py
@@ -158,13 +158,26 @@ def edit_distance_score(s1: str, s2: str):
 
 
 def rerank(keywords: str, docs: Dict[str, str], with_score: bool = False):
-    candidates = [doc for doc in docs.values()]
-    doc_dict_reverse = {val: key for key, val in docs.items()}
+    # Ensure there are no duplicate values in docs
+    robust_docs = {}
+    val_set = set()
+    for key, val in docs.items():
+        while val in val_set:
+            # Add a dummy suffix to the value
+            val += "-"
+
+        val_set.add(val)
+        robust_docs[key] = val
+
+    candidates = [doc for doc in robust_docs.values()]
+    doc_dict_reverse = {val: key for key, val in robust_docs.items()}
+
     docs_sorted = process.extract(keywords, candidates, limit=None, scorer=fuzz.partial_ratio)
     if with_score:
         id_doc_sorted = [(doc_dict_reverse[doc], doc, score) for doc, score in docs_sorted]
     else:
         id_doc_sorted = [(doc_dict_reverse[doc], doc) for doc, _ in docs_sorted]
+
     return id_doc_sorted
 
 


### PR DESCRIPTION
Hi, thank you for releasing this great benchmark!

When I tested agents on the benchmark, I found that a ground truth error may occur if duplicate values exist in a task. For example, in task 21 in ``instore`` domain, the product name ``酸汤牛肉一人食套餐`` duplicates in different products (``product id: S17564420305476295_P00005`` and ``product_id: S17564420305476295_P00017``). This would cause an error in the function ``rerank`` in ``src/vita/utils/utils.py``. Since in this function you reverse the dict, ``酸汤牛肉一人食套餐`` would be a key with 2 values. Therefore the first value would be overwritted, making the groudtruth product not to be displayed when an agent searches available products.

 I made a little modification to solve such problem. Hope it could help you improve the robustness of the benchmark :)