### PR TITLE
Add VitaBench benchmark dashboard

### DIFF
--- a/BENCHMARK_QUICKSTART_CN.md
+++ b/BENCHMARK_QUICKSTART_CN.md
@@ -1,0 +1,220 @@
+# VitaBench 评测快速上手（面向外部用户）
+
+这份文档用于把仓库整理成“开箱即可评测”的使用方式：你只需要配置自己的模型、服务商和 API Key，即可跑 VitaBench。
+
+## 0. Conda 环境（推荐）
+
+```bash
+conda create -n vitabench python=3.10 -y
+conda activate vitabench
+pip install -U pip
+pip install -e .
+```
+
+> 后续每次使用前先执行：`conda activate vitabench`
+
+## 1. VitaBench 是什么
+
+- VitaBench 总计 **400** 条任务。
+- 由 4 个 split 组成，每个 **100** 条：
+  - `delivery,instore,ota`（cross 场景）
+  - `delivery`
+  - `instore`
+  - `ota`
+- 标准完整评测就是把这 4 个 split 都跑完，再做汇总。
+
+## 2. 模型与服务配置
+
+1. 复制模板：
+
+```bash
+cp models.template.yaml models.local.yaml
+```
+
+2. 按你的服务商改 `models.local.yaml`。
+
+### 2.1 重要说明：`zai-org/glm-5.1` 与供应商
+
+- `zai-org/glm-5.1` 是当前仓库里对 **GLM-5.1 模型名的约定写法**（历史上常配 Novita）。
+- 它只是一个“模型标识符”；真正请求哪个供应商，取决于该模型条目的 `base_url` 和 `headers.Authorization`。
+- 因此：
+  - 如果你用 Novita，就把 `zai-org/glm-5.1` 指到 Novita 的接口；
+  - 如果你不用 Novita，也可以把同一个模型名指到其他供应商的 GLM-5.1 接口（只要 OpenAI 兼容）。
+
+### 2.2 Novita 配置示例（user + evaluator）
+
+```yaml
+default:
+  base_url: "https://api.novita.ai/v3/openai/chat/completions"
+  temperature: 0.0
+  max_input_tokens: 131072
+  headers:
+    Accept: "*/*"
+    Content-Type: "application/json"
+    Authorization: "Bearer ${NOVITA_API_KEY:}"
+
+models:
+  - name: "zai-org/glm-5.1"
+    max_tokens: 32768
+    max_input_tokens: 131072
+
+  - name: "your-agent-model"
+    max_tokens: 32768
+    max_input_tokens: 131072
+```
+
+### 2.3 非 Novita 的 GLM-5.1 配置示例
+
+把 `zai-org/glm-5.1` 这个条目改成你使用的供应商地址即可：
+
+```yaml
+models:
+  - name: "zai-org/glm-5.1"
+    base_url: "https://your-provider.example.com/v1/chat/completions"
+    headers:
+      Authorization: "Bearer ${GLM51_API_KEY:}"
+```
+
+### 2.4 user/evaluator 与 agent 来自不同供应商（推荐）
+
+你可以在同一个 `models.local.yaml` 中给不同模型写不同 `base_url`：
+
+```yaml
+default:
+  base_url: "https://api.novita.ai/v3/openai/chat/completions"
+  headers:
+    Authorization: "Bearer ${NOVITA_API_KEY:}"
+
+models:
+  # 固定用户模拟器与评估器：GLM-5.1（供应商 A）
+  - name: "zai-org/glm-5.1"
+    base_url: "https://api.novita.ai/v3/openai/chat/completions"
+    headers:
+      Authorization: "Bearer ${NOVITA_API_KEY:}"
+
+  # 被评测 agent：来自供应商 B
+  - name: "your-agent-model"
+    base_url: "https://api.other-provider.com/v1/chat/completions"
+    headers:
+      Authorization: "Bearer ${AGENT_API_KEY:}"
+```
+
+3. 指定配置文件并设置 key：
+
+```bash
+export VITA_MODEL_CONFIG_PATH="$(pwd)/models.local.yaml"
+export NOVITA_API_KEY="<YOUR_NOVITA_KEY>"
+export AGENT_API_KEY="<YOUR_AGENT_PROVIDER_KEY>"   # 如有第二供应商
+export GLM51_API_KEY="<YOUR_GLM51_PROVIDER_KEY>"   # 若 glm5.1 不走 Novita
+```
+
+## 3. 两种运行方式
+
+### A) 串行跑四个命令（标准流程）
+
+```bash
+vita run --domain "delivery,instore,ota" --agent-llm "your-agent-model" --user-llm "zai-org/glm-5.1" --evaluator-llm "zai-org/glm-5.1" --max-concurrency 4 --save-to "benchmark_manual/cross.json"
+vita run --domain "delivery"              --agent-llm "your-agent-model" --user-llm "zai-org/glm-5.1" --evaluator-llm "zai-org/glm-5.1" --max-concurrency 4 --save-to "benchmark_manual/delivery.json"
+vita run --domain "instore"               --agent-llm "your-agent-model" --user-llm "zai-org/glm-5.1" --evaluator-llm "zai-org/glm-5.1" --max-concurrency 4 --save-to "benchmark_manual/instore.json"
+vita run --domain "ota"                   --agent-llm "your-agent-model" --user-llm "zai-org/glm-5.1" --evaluator-llm "zai-org/glm-5.1" --max-concurrency 4 --save-to "benchmark_manual/ota.json"
+```
+
+### B) 一条命令跑完整 400 样例（推荐）
+
+```bash
+bash run_benchmark_400.sh "your-agent-model" 4 chinese
+```
+
+该脚本会自动：
+- 串行执行 cross + 三个单场景，共 400 样例
+- 固定 `user-llm` 与 `evaluator-llm` 为 `zai-org/glm-5.1`
+- 不做自动合并；四份结果保存在同一个目录
+- 在终端打印直观分数汇总（各 split 的 `avg_reward / pass^1 / 样本数`）
+
+### C) 只给 base_url + model_id，并支持并行实验
+
+如果你要同时跑多个 OpenAI-compatible endpoint，不要手动反复改同一个
+`models.local.yaml`。可以用 `run_openai_compatible_4split.sh`，它会为每个
+`RUN_NAME` 生成独立配置：
+
+```bash
+# 本地无鉴权服务
+MAX_CONCURRENCY=8 \
+bash run_openai_compatible_4split.sh \
+  "http://127.0.0.1:8000/v1" \
+  "glm-5.1-fp8" \
+  "" \
+  "exp_glm51_fp8_c8"
+
+# 外部服务
+MAX_CONCURRENCY=8 \
+bash run_openai_compatible_4split.sh \
+  "https://api.example.com/v1" \
+  "provider/model-id" \
+  "$AGENT_API_KEY" \
+  "exp_provider_model_c8"
+```
+
+生成的配置在：
+
+```bash
+data/model_configs/benchmark_runs/<run_name>.yaml
+```
+
+结果和日志仍然在：
+
+```bash
+data/simulations/benchmark_runs/<run_name>/
+data/logs/benchmark_runs/<run_name>/
+```
+
+并行跑多个实验时，给每个实验不同的 `run_name` 即可：
+
+```bash
+MAX_CONCURRENCY=8 bash run_openai_compatible_4split.sh http://host-a:8000/v1 model-a "" exp_a &
+MAX_CONCURRENCY=8 bash run_openai_compatible_4split.sh http://host-b:8000/v1 model-b "" exp_b &
+wait
+```
+
+启动前也可以先只生成配置、不跑评测：
+
+```bash
+DRY_RUN=1 bash run_openai_compatible_4split.sh http://host-a:8000/v1 model-a "" exp_a
+```
+
+## 4. 输出位置
+
+- 单次运行目录（带时间戳）：
+  - 结果文件：`data/simulations/benchmark_runs/<timestamp>/`
+  - 日志文件：`data/logs/benchmark_runs/<timestamp>/`
+- 结果文件共 4 个：
+  - `delivery,instore,ota.json`
+  - `delivery.json`
+  - `instore.json`
+  - `ota.json`
+
+## 5. 可视化查看（支持目录）
+
+推荐使用 Web 看板查看进行中或已完成的 benchmark run：
+
+```bash
+PYTHONPATH=src python3 -m vita.cli board --host 0.0.0.0 --port 8765
+```
+
+打开 `http://127.0.0.1:8765/dashboard`，可查看每个实验的 split 进度、分数摘要，并点击 split 展开日志 tail。
+
+现在可以直接把目录传给 `vita view`：
+
+```bash
+vita view --file "data/simulations/benchmark_runs/<timestamp>"
+```
+
+它会自动读取目录中的 `*.json` 结果文件，便于批量查看。
+
+## 6. 环境安装（首次）
+
+```bash
+pip install -e .
+```
+
+安装完成后可以直接使用 `vita` 命令。

--- a/BENCHMARK_QUICKSTART_CN.md
+++ b/BENCHMARK_QUICKSTART_CN.md
@@ -203,6 +203,23 @@ PYTHONPATH=src python3 -m vita.cli board --host 0.0.0.0 --port 8765
 
 打开 `http://127.0.0.1:8765/dashboard`，可查看每个实验的 split 进度、分数摘要，并点击 split 展开日志 tail。
 
+默认数据源：
+
+- logs：`data/logs`，看板会读取其中的 `benchmark_runs/<run_name>/`
+- results：`data/simulations`，看板会读取其中的 `benchmark_runs/<run_name>/`
+
+如需指定数据源：
+
+```bash
+PYTHONPATH=src python3 -m vita.cli board \
+  --host 0.0.0.0 \
+  --port 8765 \
+  --logs-dir /path/to/logs \
+  --simulations-dir /path/to/simulations
+```
+
+`--logs-dir` 和 `--simulations-dir` 可以传根目录，也可以传已经包含 `benchmark_runs` 的目录。
+
 现在可以直接把目录传给 `vita view`：
 
 ```bash

--- a/scripts/tcp_proxy.py
+++ b/scripts/tcp_proxy.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import argparse
+import asyncio
+import signal
+import time
+
+
+def _timestamp() -> str:
+    return time.strftime("%F %T")
+
+
+def _ignore_sigterm() -> None:
+    print(f"{_timestamp()} proxy ignored SIGTERM", flush=True)
+
+
+async def _pipe(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    try:
+        while data := await reader.read(65536):
+            writer.write(data)
+            await writer.drain()
+    except Exception:
+        pass
+    finally:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+
+async def _handle(
+    target_host: str,
+    target_port: int,
+    client_reader: asyncio.StreamReader,
+    client_writer: asyncio.StreamWriter,
+) -> None:
+    try:
+        upstream_reader, upstream_writer = await asyncio.open_connection(
+            target_host, target_port
+        )
+    except Exception:
+        client_writer.close()
+        return
+    await asyncio.gather(
+        _pipe(client_reader, upstream_writer),
+        _pipe(upstream_reader, client_writer),
+    )
+
+
+async def _main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--listen-host", default="0.0.0.0")
+    parser.add_argument("--listen-port", type=int, required=True)
+    parser.add_argument("--target-host", default="127.0.0.1")
+    parser.add_argument("--target-port", type=int, required=True)
+    args = parser.parse_args()
+
+    loop = asyncio.get_running_loop()
+    try:
+        loop.add_signal_handler(signal.SIGTERM, _ignore_sigterm)
+    except NotImplementedError:
+        signal.signal(signal.SIGTERM, lambda *_args: _ignore_sigterm())
+
+    server = await asyncio.start_server(
+        lambda reader, writer: _handle(
+            args.target_host, args.target_port, reader, writer
+        ),
+        args.listen_host,
+        args.listen_port,
+        reuse_address=True,
+    )
+    print(
+        f"{_timestamp()} proxy listening "
+        f"{args.listen_host}:{args.listen_port} -> "
+        f"{args.target_host}:{args.target_port}",
+        flush=True,
+    )
+    async with server:
+        await server.serve_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/src/vita/cli.py
+++ b/src/vita/cli.py
@@ -259,6 +259,12 @@ def main():
         default=None,
         help="Custom logs directory, default is data/logs.",
     )
+    log_view_parser.add_argument(
+        "--simulations-dir",
+        type=str,
+        default=None,
+        help="Custom simulations/results directory, default is data/simulations.",
+    )
     log_view_parser.set_defaults(func=lambda args: run_log_viewer(args))
 
     # Benchmark dashboard command
@@ -283,6 +289,12 @@ def main():
         type=str,
         default=None,
         help="Custom logs directory, default is data/logs.",
+    )
+    board_parser.add_argument(
+        "--simulations-dir",
+        type=str,
+        default=None,
+        help="Custom simulations/results directory, default is data/simulations.",
     )
     board_parser.set_defaults(func=lambda args: run_log_viewer(args))
 
@@ -317,7 +329,7 @@ def run_log_viewer(args):
 
     from vita.scripts.log_viewer import create_app
 
-    app = create_app(logs_dir=args.logs_dir)
+    app = create_app(logs_dir=args.logs_dir, simulations_dir=args.simulations_dir)
     uvicorn.run(app, host=args.host, port=args.port)
 
 

--- a/src/vita/cli.py
+++ b/src/vita/cli.py
@@ -236,6 +236,56 @@ def main():
     )
     view_parser.set_defaults(func=lambda args: run_view_simulations(args))
 
+    # Log viewer command
+    log_view_parser = subparsers.add_parser(
+        "log-view",
+        help="Start Web UI: / dashboard, /events JSONL events, /trajectory full traces.",
+    )
+    log_view_parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help="Host for web UI server.",
+    )
+    log_view_parser.add_argument(
+        "--port",
+        type=int,
+        default=8765,
+        help="Port for web UI server.",
+    )
+    log_view_parser.add_argument(
+        "--logs-dir",
+        type=str,
+        default=None,
+        help="Custom logs directory, default is data/logs.",
+    )
+    log_view_parser.set_defaults(func=lambda args: run_log_viewer(args))
+
+    # Benchmark dashboard command
+    board_parser = subparsers.add_parser(
+        "board",
+        help="Start VitaBench benchmark dashboard with run progress and split logs.",
+    )
+    board_parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help="Host for web UI server.",
+    )
+    board_parser.add_argument(
+        "--port",
+        type=int,
+        default=8765,
+        help="Port for web UI server.",
+    )
+    board_parser.add_argument(
+        "--logs-dir",
+        type=str,
+        default=None,
+        help="Custom logs directory, default is data/logs.",
+    )
+    board_parser.set_defaults(func=lambda args: run_log_viewer(args))
+
     # Domain command
     domain_parser = subparsers.add_parser("domain", help="Show domain documentation")
     domain_parser.add_argument(
@@ -260,6 +310,16 @@ def run_view_simulations(args):
         only_show_failed=args.only_show_failed,
         only_show_all_failed=args.only_show_all_failed,
     )
+
+
+def run_log_viewer(args):
+    import uvicorn
+
+    from vita.scripts.log_viewer import create_app
+
+    app = create_app(logs_dir=args.logs_dir)
+    uvicorn.run(app, host=args.host, port=args.port)
+
 
 if __name__ == "__main__":
     main()

--- a/src/vita/scripts/log_viewer.py
+++ b/src/vita/scripts/log_viewer.py
@@ -690,7 +690,7 @@ def create_app(logs_dir: Optional[str] = None) -> FastAPI:
                 detail=f"sim_index out of range: {sim_index} (have {len(results.simulations)} simulations)",
             )
         sim = results.simulations[sim_index]
-        timeline = build_timeline_from_simulation(sim)
+        timeline = build_timeline_from_simulation(sim, results)
         if not include_raw:
             for row in timeline:
                 if row.get("kind") in ("assistant", "user"):

--- a/src/vita/scripts/log_viewer.py
+++ b/src/vita/scripts/log_viewer.py
@@ -25,7 +25,12 @@ from vita.utils.task_sorting import simulation_sort_key, task_id_sort_key
 from vita.utils.utils import DATA_DIR
 
 
+SIMULATIONS_DIR_OVERRIDE: Optional[Path] = None
+
+
 def _simulations_dir() -> Path:
+    if SIMULATIONS_DIR_OVERRIDE is not None:
+        return SIMULATIONS_DIR_OVERRIDE
     return DATA_DIR / "simulations"
 
 
@@ -40,7 +45,11 @@ def _allowed_simulation_roots() -> list[Path]:
 
 
 def _benchmark_simulations_dir() -> Path:
-    return _simulations_dir() / "benchmark_runs"
+    simulations_dir = _simulations_dir()
+    benchmark_dir = simulations_dir / "benchmark_runs"
+    if benchmark_dir.exists() or not simulations_dir.name == "benchmark_runs":
+        return benchmark_dir
+    return simulations_dir
 
 
 def _benchmark_logs_dir(base_logs_dir: Path) -> Path:
@@ -456,7 +465,11 @@ def _is_non_full_reward(sim) -> bool:
         return True
 
 
-def create_app(logs_dir: Optional[str] = None) -> FastAPI:
+def create_app(
+    logs_dir: Optional[str] = None, simulations_dir: Optional[str] = None
+) -> FastAPI:
+    global SIMULATIONS_DIR_OVERRIDE
+    SIMULATIONS_DIR_OVERRIDE = Path(simulations_dir) if simulations_dir else None
     app = FastAPI(title="VitaBench Log Viewer")
     base_logs_dir = Path(logs_dir) if logs_dir else DATA_DIR / "logs"
     static_dir = Path(__file__).parents[1] / "web"

--- a/src/vita/scripts/log_viewer.py
+++ b/src/vita/scripts/log_viewer.py
@@ -447,6 +447,15 @@ def _trial_sort_key(trial: object) -> int:
         return -1
 
 
+def _is_non_full_reward(sim) -> bool:
+    if sim.reward_info is None:
+        return True
+    try:
+        return float(sim.reward_info.reward) < 1.0
+    except (TypeError, ValueError):
+        return True
+
+
 def create_app(logs_dir: Optional[str] = None) -> FastAPI:
     app = FastAPI(title="VitaBench Log Viewer")
     base_logs_dir = Path(logs_dir) if logs_dir else DATA_DIR / "logs"
@@ -651,10 +660,18 @@ def create_app(logs_dir: Optional[str] = None) -> FastAPI:
         file: str = Query(..., description="simulations 目录下的 json 相对路径"),
         offset: int = Query(0, ge=0),
         limit: Optional[int] = Query(None, ge=1, le=5000),
+        reward_filter: Optional[str] = Query(None, pattern="^(non_full)$"),
     ) -> dict:
         path = _resolve_simulation_file(file)
         results = Results.model_validate_json(path.read_text(encoding="utf-8"))
         sorted_rows = _sorted_simulation_rows(results)
+        unfiltered_count = len(sorted_rows)
+        if reward_filter == "non_full":
+            sorted_rows = [
+                (original_index, sim)
+                for original_index, sim in sorted_rows
+                if _is_non_full_reward(sim)
+            ]
         visible_rows = sorted_rows[offset : offset + limit] if limit is not None else sorted_rows
         runs = []
         for display_index, (original_index, sim) in enumerate(visible_rows, start=offset):
@@ -671,6 +688,8 @@ def create_app(logs_dir: Optional[str] = None) -> FastAPI:
             "task_count": len(results.tasks),
             "simulation_count": len(results.simulations),
             "total_count": len(sorted_rows),
+            "unfiltered_count": unfiltered_count,
+            "reward_filter": reward_filter,
             "offset": offset,
             "limit": limit,
             "runs": runs,

--- a/src/vita/scripts/log_viewer.py
+++ b/src/vita/scripts/log_viewer.py
@@ -1,0 +1,796 @@
+import json
+import re
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.responses import HTMLResponse, PlainTextResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from vita.data_model.message import ToolCall
+from vita.data_model.simulation import Results
+from vita.environment.environment import get_cross_environment
+from vita.metrics.agent_metrics import compute_metrics
+from vita.registry import registry
+from vita.utils.simulation_timeline import (
+    build_timeline_from_simulation,
+    build_user_simulator_profile,
+    format_json_for_display,
+    simulation_run_summary,
+)
+from vita.utils.task_sorting import simulation_sort_key, task_id_sort_key
+from vita.utils.utils import DATA_DIR
+
+
+def _simulations_dir() -> Path:
+    return DATA_DIR / "simulations"
+
+
+def _allowed_simulation_roots() -> list[Path]:
+    roots = [_simulations_dir().resolve()]
+    share_root = Path(
+        "/vePFS-Mindverse/share/mutian/vitabench/vitabench/data/simulations"
+    )
+    if share_root.exists():
+        roots.append(share_root.resolve())
+    return roots
+
+
+def _benchmark_simulations_dir() -> Path:
+    return _simulations_dir() / "benchmark_runs"
+
+
+def _benchmark_logs_dir(base_logs_dir: Path) -> Path:
+    benchmark_dir = base_logs_dir / "benchmark_runs"
+    if benchmark_dir.exists() or not base_logs_dir.name == "benchmark_runs":
+        return benchmark_dir
+    return base_logs_dir
+
+
+BENCHMARK_SPLITS = [
+    {
+        "key": "delivery",
+        "label": "delivery",
+        "domain": "delivery",
+        "log_names": ["delivery.log"],
+        "result_names": ["delivery.json"],
+    },
+    {
+        "key": "ota",
+        "label": "ota",
+        "domain": "ota",
+        "log_names": ["ota.log"],
+        "result_names": ["ota.json"],
+    },
+    {
+        "key": "instore",
+        "label": "instore",
+        "domain": "instore",
+        "log_names": ["instore.log"],
+        "result_names": ["instore.json"],
+    },
+    {
+        "key": "cross",
+        "label": "cross",
+        "domain": "delivery,instore,ota",
+        "log_names": ["cross.log", "delivery,instore,ota.log"],
+        "result_names": ["cross.json", "delivery,instore,ota.json"],
+    },
+]
+
+
+def _resolve_simulation_file(file: str) -> Path:
+    """仅允许读取 data/simulations 下的 .json 相对路径，防止路径穿越。"""
+    if not file or "\\" in file:
+        raise HTTPException(status_code=400, detail="invalid simulation file path")
+    rel = Path(file)
+    if not file.endswith(".json"):
+        raise HTTPException(status_code=400, detail="simulation file must end with .json")
+    if rel.is_absolute():
+        path = rel.resolve()
+    else:
+        if any(part in ("", ".", "..") for part in rel.parts):
+            raise HTTPException(status_code=400, detail="invalid simulation file path")
+        if any(part.startswith(".") for part in rel.parts):
+            raise HTTPException(status_code=400, detail="invalid simulation file path")
+        roots = _allowed_simulation_roots()
+        path = (roots[0] / rel).resolve()
+        for root in roots:
+            candidate = (root / rel).resolve()
+            if candidate.exists():
+                path = candidate
+                break
+    for root in _allowed_simulation_roots():
+        try:
+            path.relative_to(root)
+            break
+        except ValueError:
+            continue
+    else:
+        raise HTTPException(status_code=403, detail="path outside allowed simulations dirs")
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail=f"simulation file not found: {file}")
+    return path
+
+
+def _load_events(file_path: Path) -> list[dict]:
+    events = []
+    with open(file_path, "r", encoding="utf-8") as fp:
+        for line in fp:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return events
+
+
+def _safe_child_dir(root: Path, name: str, label: str) -> Path:
+    if not name or "\\" in name:
+        raise HTTPException(status_code=400, detail=f"invalid {label}")
+    rel = Path(name)
+    if rel.is_absolute() or len(rel.parts) != 1 or rel.parts[0] in (".", ".."):
+        raise HTTPException(status_code=400, detail=f"invalid {label}")
+    if rel.name.startswith("."):
+        raise HTTPException(status_code=400, detail=f"invalid {label}")
+    path = (root / rel.name).resolve()
+    try:
+        path.relative_to(root.resolve())
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail=f"{label} outside root") from exc
+    return path
+
+
+def _read_tail(path: Optional[Path], max_bytes: int = 256_000) -> str:
+    if path is None or not path.exists() or not path.is_file():
+        return ""
+    size = path.stat().st_size
+    with open(path, "rb") as fp:
+        if size > max_bytes:
+            fp.seek(size - max_bytes)
+            fp.readline()
+        return fp.read().decode("utf-8", errors="replace")
+
+
+def _count_completed_from_log(path: Optional[Path]) -> int:
+    if path is None or not path.exists() or not path.is_file():
+        return 0
+    task_ids = set()
+    pattern = re.compile(r"Orchestrator\.run 结束 task_id=([^\s]+)")
+    with open(path, "r", encoding="utf-8", errors="replace") as fp:
+        for line in fp:
+            match = pattern.search(line)
+            if match:
+                task_ids.add(match.group(1))
+    return len(task_ids)
+
+
+def _split_file(base_dir: Optional[Path], names: list[str]) -> Optional[Path]:
+    if base_dir is None or not base_dir.exists():
+        return None
+    for name in names:
+        path = base_dir / name
+        if path.exists():
+            return path
+    return None
+
+
+def _result_path_from_log(path: Optional[Path]) -> Optional[Path]:
+    if path is None or not path.exists() or not path.is_file():
+        return None
+    found = None
+    pattern = re.compile(r"save_to=([^\s]+\.json)")
+    with open(path, "r", encoding="utf-8", errors="replace") as fp:
+        for line in fp:
+            match = pattern.search(line)
+            if match:
+                found = Path(match.group(1))
+    if found is not None and found.is_absolute() and found.exists():
+        return found
+    return None
+
+
+def _load_result_summary(path: Optional[Path], include_metrics: bool = True) -> dict:
+    if path is None or not path.exists():
+        return {}
+    if not include_metrics:
+        return {"samples": 100, "tasks": 100}
+    try:
+        results = Results.load(path)
+        metrics = compute_metrics(results)
+        return {
+            "samples": len(results.simulations),
+            "tasks": len(results.tasks),
+            "avg_reward": metrics.avg_reward,
+            "pass1": metrics.pass_hat_ks.get(1),
+            "duration_sec": metrics.total_duration,
+        }
+    except Exception as exc:
+        return {"error": f"{type(exc).__name__}: {exc}"}
+
+
+def _simulation_view_file(path: Optional[Path]) -> Optional[str]:
+    if path is None:
+        return None
+    resolved = path.resolve()
+    for root in _allowed_simulation_roots():
+        try:
+            return resolved.relative_to(root).as_posix()
+        except ValueError:
+            continue
+    return str(resolved)
+
+
+def _split_summary(
+    run_name: str,
+    split: dict,
+    logs_dir: Optional[Path],
+    simulations_dir: Optional[Path],
+    include_metrics: bool = True,
+) -> dict:
+    log_path = _split_file(logs_dir, split["log_names"])
+    result_path = _split_file(simulations_dir, split["result_names"]) or _result_path_from_log(log_path)
+    result = _load_result_summary(result_path, include_metrics=include_metrics)
+    expected = int(result.get("tasks") or 100)
+    completed = max(
+        int(result.get("samples") or 0),
+        int(_count_completed_from_log(log_path) or 0),
+    )
+    completed = min(completed, expected)
+    tail = _read_tail(log_path, max_bytes=96_000)
+    has_success_marker = "Successfully completed all simulations!" in tail
+    is_recent = bool(log_path and log_path.exists() and time.time() - log_path.stat().st_mtime < 300)
+    has_complete_result = bool(
+        result_path and result_path.exists() and "error" not in result and completed >= expected
+    )
+    status = "pending"
+    if has_complete_result or has_success_marker:
+        status = "complete"
+        completed = expected
+    elif is_recent:
+        status = "running"
+    elif re.search(r"(FAILED|Fatal|Error loading|HTTPError)", tail):
+        status = "failed"
+    elif log_path and log_path.exists():
+        status = "running"
+    mtime_candidates = [
+        p.stat().st_mtime
+        for p in (log_path, result_path)
+        if p is not None and p.exists()
+    ]
+    return {
+        "run_name": run_name,
+        "key": split["key"],
+        "label": split["label"],
+        "domain": split["domain"],
+        "status": status,
+        "completed": completed,
+        "expected": expected,
+        "progress": completed / expected if expected else 0,
+        "log_file": log_path.name if log_path else None,
+        "log_size": log_path.stat().st_size if log_path else 0,
+        "log_mtime": log_path.stat().st_mtime if log_path else None,
+        "result_file": str(result_path) if result_path and result_path.is_absolute() else (result_path.name if result_path else None),
+        "result_view_file": _simulation_view_file(result_path),
+        "result_size": result_path.stat().st_size if result_path else 0,
+        "result_mtime": result_path.stat().st_mtime if result_path else None,
+        "mtime": max(mtime_candidates) if mtime_candidates else None,
+        "metrics": result,
+    }
+
+
+def _extra_split_summaries(
+    run_name: str,
+    logs_dir: Optional[Path],
+    simulations_dir: Optional[Path],
+    known_log_names: set[str],
+    known_result_names: set[str],
+) -> list[dict]:
+    extras = []
+    if logs_dir and logs_dir.exists():
+        for path in sorted(logs_dir.glob("*.log")):
+            if path.name in known_log_names:
+                continue
+            stem = path.stem
+            extras.append(
+                _split_summary(
+                    run_name,
+                    {
+                        "key": stem,
+                        "label": stem,
+                        "domain": stem,
+                        "log_names": [path.name],
+                        "result_names": [f"{stem}.json"],
+                    },
+                    logs_dir,
+                    simulations_dir,
+                    include_metrics=False,
+                )
+            )
+    if simulations_dir and simulations_dir.exists():
+        existing_keys = {row["key"] for row in extras}
+        for path in sorted(simulations_dir.glob("*.json")):
+            if path.name in known_result_names or path.stem in existing_keys:
+                continue
+            stem = path.stem
+            extras.append(
+                _split_summary(
+                    run_name,
+                    {
+                        "key": stem,
+                        "label": stem,
+                        "domain": stem,
+                        "log_names": [f"{stem}.log"],
+                        "result_names": [path.name],
+                    },
+                    logs_dir,
+                    simulations_dir,
+                    include_metrics=False,
+                )
+            )
+    return extras
+
+
+def _benchmark_run_summary(
+    run_name: str,
+    benchmark_logs_root: Path,
+    benchmark_sim_root: Path,
+    include_metrics: bool = True,
+) -> dict:
+    logs_dir = benchmark_logs_root / run_name
+    simulations_dir = benchmark_sim_root / run_name
+    known_log_names = {name for split in BENCHMARK_SPLITS for name in split["log_names"]}
+    known_result_names = {
+        name for split in BENCHMARK_SPLITS for name in split["result_names"]
+    }
+    splits = [
+        _split_summary(
+            run_name,
+            split,
+            logs_dir,
+            simulations_dir,
+            include_metrics=include_metrics,
+        )
+        for split in BENCHMARK_SPLITS
+    ]
+    splits.extend(
+        _extra_split_summaries(
+            run_name, logs_dir, simulations_dir, known_log_names, known_result_names
+        )
+    )
+    visible = [s for s in splits if s["status"] != "pending" or s["completed"] > 0]
+    status_values = [s["status"] for s in visible]
+    if not visible:
+        status = "pending"
+    elif any(s == "running" for s in status_values):
+        status = "running"
+    elif any(s == "failed" for s in status_values):
+        status = "failed"
+    elif all(s == "complete" for s in status_values) and len(visible) >= 4:
+        status = "complete"
+    else:
+        status = "partial"
+    mtimes = [s["mtime"] for s in visible if s["mtime"] is not None]
+    completed_samples = sum(int(s["completed"]) for s in splits)
+    expected_samples = sum(int(s["expected"]) for s in splits) or 400
+    completed_splits = sum(1 for s in visible if s["status"] == "complete")
+    return {
+        "run_name": run_name,
+        "status": status,
+        "completed_splits": completed_splits,
+        "total_splits": max(len(visible), 4),
+        "completed_samples": completed_samples,
+        "expected_samples": expected_samples,
+        "progress": completed_samples / expected_samples if expected_samples else 0,
+        "last_update": max(mtimes) if mtimes else None,
+        "age_seconds": (time.time() - max(mtimes)) if mtimes else None,
+        "logs_dir": str(logs_dir) if logs_dir.exists() else None,
+        "simulations_dir": str(simulations_dir) if simulations_dir.exists() else None,
+        "splits": splits,
+    }
+
+
+def _run_dir_mtime(run_name: str, benchmark_logs_root: Path, benchmark_sim_root: Path) -> float:
+    mtimes = []
+    for root in (benchmark_logs_root, benchmark_sim_root):
+        path = root / run_name
+        if path.exists():
+            mtimes.append(path.stat().st_mtime)
+            for child in path.glob("*"):
+                if child.is_file():
+                    mtimes.append(child.stat().st_mtime)
+    return max(mtimes) if mtimes else 0.0
+
+
+class ToolInvokeRequest(BaseModel):
+    file: str
+    sim_index: int
+    tool_name: str
+    arguments: dict = {}
+
+
+def _resolve_task_from_simulation(results: Results, sim_index: int):
+    if sim_index >= len(results.simulations):
+        raise HTTPException(
+            status_code=400,
+            detail=f"sim_index out of range: {sim_index} (have {len(results.simulations)} simulations)",
+        )
+    sim = results.simulations[sim_index]
+    task = next((t for t in results.tasks if t.id == sim.task_id), None)
+    if task is None:
+        raise HTTPException(
+            status_code=404, detail=f"task not found in results.tasks: {sim.task_id}"
+        )
+    return sim, task
+
+
+def _build_environment_for_task(task, language: str = "chinese"):
+    if "," in task.domain:
+        return get_cross_environment(task.domain, task.environment, language)
+    env_constructor = registry.get_env_constructor(task.domain)
+    return env_constructor(task.environment, language)
+
+
+def _sorted_simulation_rows(results: Results) -> list[tuple[int, object]]:
+    return sorted(enumerate(results.simulations), key=lambda row: simulation_sort_key(row[1]))
+
+
+def _trial_sort_key(trial: object) -> int:
+    try:
+        return int(trial)
+    except (TypeError, ValueError):
+        return -1
+
+
+def create_app(logs_dir: Optional[str] = None) -> FastAPI:
+    app = FastAPI(title="VitaBench Log Viewer")
+    base_logs_dir = Path(logs_dir) if logs_dir else DATA_DIR / "logs"
+    static_dir = Path(__file__).parents[1] / "web"
+    app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+    @app.get("/", response_class=HTMLResponse)
+    def index() -> str:
+        p = static_dir / "dashboard.html"
+        if not p.exists():
+            raise HTTPException(status_code=404, detail="dashboard.html not found")
+        return p.read_text(encoding="utf-8")
+
+    @app.get("/dashboard", response_class=HTMLResponse)
+    def dashboard_page() -> str:
+        p = static_dir / "dashboard.html"
+        if not p.exists():
+            raise HTTPException(status_code=404, detail="dashboard.html not found")
+        return p.read_text(encoding="utf-8")
+
+    @app.get("/events", response_class=HTMLResponse)
+    def events_page() -> str:
+        p = static_dir / "index.html"
+        if not p.exists():
+            raise HTTPException(status_code=404, detail="index.html not found")
+        return p.read_text(encoding="utf-8")
+
+    @app.get("/trajectory", response_class=HTMLResponse)
+    def trajectory_page() -> str:
+        p = static_dir / "trajectory.html"
+        if not p.exists():
+            raise HTTPException(status_code=404, detail="trajectory.html not found")
+        return p.read_text(encoding="utf-8")
+
+    @app.get("/toolbox", response_class=HTMLResponse)
+    def toolbox_page() -> str:
+        p = static_dir / "tools.html"
+        if not p.exists():
+            raise HTTPException(status_code=404, detail="tools.html not found")
+        return p.read_text(encoding="utf-8")
+
+    @app.get("/api/benchmark-runs")
+    def benchmark_runs(
+        run_name: Optional[str] = Query(None),
+        limit: int = Query(80, ge=1, le=500),
+    ) -> dict:
+        benchmark_logs_root = _benchmark_logs_dir(base_logs_dir)
+        benchmark_sim_root = _benchmark_simulations_dir()
+        run_names = set()
+        for root in (benchmark_logs_root, benchmark_sim_root):
+            if root.exists():
+                run_names.update(p.name for p in root.iterdir() if p.is_dir())
+        if run_name:
+            _safe_child_dir(benchmark_logs_root, run_name, "run_name")
+            run_names = {run_name}
+        else:
+            run_names = set(
+                sorted(
+                    run_names,
+                    key=lambda name: _run_dir_mtime(
+                        name, benchmark_logs_root, benchmark_sim_root
+                    ),
+                    reverse=True,
+                )[:limit]
+            )
+        runs = [
+            _benchmark_run_summary(
+                name,
+                benchmark_logs_root,
+                benchmark_sim_root,
+                include_metrics=run_name is not None,
+            )
+            for name in run_names
+        ]
+        runs.sort(key=lambda r: r["last_update"] or 0, reverse=True)
+        return {
+            "runs": runs,
+            "logs_root": str(benchmark_logs_root),
+            "simulations_root": str(benchmark_sim_root),
+        }
+
+    @app.get("/api/health")
+    def health() -> dict:
+        return {"ok": True}
+
+    @app.get("/api/benchmark-log", response_class=PlainTextResponse)
+    def benchmark_log(
+        run_name: str = Query(...),
+        split: str = Query(...),
+        lines: int = Query(300, ge=1, le=5000),
+    ) -> str:
+        benchmark_logs_root = _benchmark_logs_dir(base_logs_dir)
+        run_dir = _safe_child_dir(benchmark_logs_root, run_name, "run_name")
+        if not run_dir.exists():
+            raise HTTPException(status_code=404, detail=f"run log dir not found: {run_name}")
+        split_defs = {
+            s["key"]: s
+            for s in BENCHMARK_SPLITS
+        }
+        split_def = split_defs.get(split)
+        if split_def is None:
+            if not re.fullmatch(r"[A-Za-z0-9_.=,-]+", split):
+                raise HTTPException(status_code=400, detail="invalid split")
+            split_def = {"log_names": [f"{split}.log"]}
+        path = _split_file(run_dir, split_def["log_names"])
+        if path is None or not path.exists():
+            raise HTTPException(status_code=404, detail=f"log not found: {split}")
+        text = _read_tail(path, max_bytes=1_000_000)
+        tail_lines = text.splitlines()[-lines:]
+        return "\n".join(tail_lines)
+
+    @app.get("/api/runs")
+    def list_runs() -> dict:
+        if not base_logs_dir.exists():
+            return {"runs": []}
+        runs = []
+        for fp in sorted(base_logs_dir.glob("*.jsonl"), reverse=True):
+            events = _load_events(fp)
+            run_id = fp.stem
+            total_events = len(events)
+            simulations = sorted(
+                {
+                    f"{event.get('task_id')}#{event.get('trial')}"
+                    for event in events
+                    if event.get("task_id") is not None and event.get("trial") is not None
+                },
+                key=lambda item: (
+                    task_id_sort_key(item.rsplit("#", 1)[0]),
+                    _trial_sort_key(item.rsplit("#", 1)[1]),
+                ),
+            )
+            runs.append(
+                {
+                    "run_id": run_id,
+                    "file_name": fp.name,
+                    "total_events": total_events,
+                    "simulations": simulations,
+                }
+            )
+        return {"runs": runs}
+
+    @app.get("/api/events")
+    def get_events(
+        run_id: str = Query(...),
+        task_id: Optional[str] = Query(None),
+        trial: Optional[int] = Query(None),
+        event_type: Optional[str] = Query(None),
+        q: Optional[str] = Query(None),
+        limit: int = Query(500, ge=1, le=5000),
+    ) -> dict:
+        file_path = base_logs_dir / f"{run_id}.jsonl"
+        if not file_path.exists():
+            raise HTTPException(status_code=404, detail=f"run log not found: {run_id}")
+
+        events = _load_events(file_path)
+        filtered = []
+        for event in events:
+            if task_id is not None and event.get("task_id") != task_id:
+                continue
+            if trial is not None and event.get("trial") != trial:
+                continue
+            if event_type is not None and event.get("event_type") != event_type:
+                continue
+            if q is not None and q.strip():
+                raw = json.dumps(event, ensure_ascii=False)
+                if q.strip().lower() not in raw.lower():
+                    continue
+            filtered.append(event)
+
+        return {
+            "run_id": run_id,
+            "count": len(filtered),
+            "events": filtered[:limit],
+            "truncated": len(filtered) > limit,
+        }
+
+    @app.get("/api/simulations")
+    def list_simulation_files() -> dict:
+        d = _simulations_dir()
+        if not d.exists():
+            return {"files": []}
+        files = []
+        for fp in sorted(d.rglob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True):
+            st = fp.stat()
+            rel = fp.relative_to(d).as_posix()
+            files.append(
+                {
+                    "name": rel,
+                    "path": rel,
+                    "basename": fp.name,
+                    "dir": fp.parent.relative_to(d).as_posix()
+                    if fp.parent != d
+                    else "",
+                    "mtime": st.st_mtime,
+                    "size": st.st_size,
+                }
+            )
+        return {"files": files}
+
+    @app.get("/api/simulation-runs")
+    def simulation_runs(
+        file: str = Query(..., description="simulations 目录下的 json 相对路径"),
+        offset: int = Query(0, ge=0),
+        limit: Optional[int] = Query(None, ge=1, le=5000),
+    ) -> dict:
+        path = _resolve_simulation_file(file)
+        results = Results.model_validate_json(path.read_text(encoding="utf-8"))
+        sorted_rows = _sorted_simulation_rows(results)
+        visible_rows = sorted_rows[offset : offset + limit] if limit is not None else sorted_rows
+        runs = []
+        for display_index, (original_index, sim) in enumerate(visible_rows, start=offset):
+            runs.append(
+                {
+                    "display_index": display_index,
+                    "index": original_index,
+                    "original_index": original_index,
+                    **simulation_run_summary(sim),
+                }
+            )
+        return {
+            "file": file,
+            "task_count": len(results.tasks),
+            "simulation_count": len(results.simulations),
+            "total_count": len(sorted_rows),
+            "offset": offset,
+            "limit": limit,
+            "runs": runs,
+        }
+
+    @app.get("/api/simulation-timeline")
+    def simulation_timeline(
+        file: str = Query(..., description="simulations 目录下的 json 相对路径"),
+        sim_index: int = Query(0, ge=0, description="results.simulations 中的下标"),
+        include_raw: bool = Query(True, description="是否在每条 assistant/user 中包含 raw_data"),
+    ) -> dict:
+        path = _resolve_simulation_file(file)
+        results = Results.model_validate_json(path.read_text(encoding="utf-8"))
+        if sim_index >= len(results.simulations):
+            raise HTTPException(
+                status_code=400,
+                detail=f"sim_index out of range: {sim_index} (have {len(results.simulations)} simulations)",
+            )
+        sim = results.simulations[sim_index]
+        timeline = build_timeline_from_simulation(sim)
+        if not include_raw:
+            for row in timeline:
+                if row.get("kind") in ("assistant", "user"):
+                    row.pop("raw_data", None)
+        return {
+            "file": file,
+            "sim_index": sim_index,
+            "summary": simulation_run_summary(sim),
+            "evaluation_result": sim.reward_info.model_dump(mode="json")
+            if sim.reward_info is not None
+            else None,
+            "user_simulator_profile": build_user_simulator_profile(
+                results, sim.task_id
+            ),
+            "timeline": timeline,
+        }
+
+    @app.get("/api/simulation-raw-json")
+    def simulation_raw_json(
+        file: str = Query(...),
+        sim_index: int = Query(0, ge=0),
+        section: str = Query(
+            "messages",
+            description="messages | full — full 为整份 Results JSON（可能很大）",
+        ),
+    ) -> dict:
+        path = _resolve_simulation_file(file)
+        raw_text = path.read_text(encoding="utf-8")
+        if section == "full":
+            return {
+                "file": file,
+                "format": "json",
+                "text": format_json_for_display(json.loads(raw_text)),
+            }
+        results = Results.model_validate_json(raw_text)
+        if sim_index >= len(results.simulations):
+            raise HTTPException(status_code=400, detail="sim_index out of range")
+        sim = results.simulations[sim_index]
+        return {
+            "file": file,
+            "sim_index": sim_index,
+            "format": "json",
+            "text": format_json_for_display(
+                [m.model_dump(mode="json") for m in sim.messages]
+            ),
+        }
+
+    @app.get("/api/simulation-tools")
+    def simulation_tools(
+        file: str = Query(..., description="simulations 目录下的 json 相对路径"),
+        sim_index: int = Query(0, ge=0),
+    ) -> dict:
+        path = _resolve_simulation_file(file)
+        results = Results.model_validate_json(path.read_text(encoding="utf-8"))
+        sim, task = _resolve_task_from_simulation(results, sim_index)
+        env = _build_environment_for_task(task)
+        tools = []
+        for t in env.get_tools():
+            tools.append(
+                {
+                    "name": t.name,
+                    "short_desc": t.short_desc,
+                    "long_desc": t.long_desc,
+                    "openai_schema": t.openai_schema,
+                    "params_schema": t.params.model_json_schema(),
+                    "returns_schema": t.returns.model_json_schema(),
+                    "raises": t.raises,
+                    "examples": t.examples,
+                }
+            )
+        tools.sort(key=lambda x: x["name"])
+        return {
+            "file": file,
+            "sim_index": sim_index,
+            "task_id": sim.task_id,
+            "domain": task.domain,
+            "note": "工具调用基于该任务的初始 environment 状态，不会自动回放到某一轮对话后的中间状态。",
+            "tools": tools,
+        }
+
+    @app.post("/api/simulation-tool-invoke")
+    def simulation_tool_invoke(req: ToolInvokeRequest) -> dict:
+        path = _resolve_simulation_file(req.file)
+        results = Results.model_validate_json(path.read_text(encoding="utf-8"))
+        sim, task = _resolve_task_from_simulation(results, req.sim_index)
+        env = _build_environment_for_task(task)
+        tool_msg = env.get_response(
+            ToolCall(
+                id=f"debug_{uuid.uuid4().hex[:12]}",
+                name=req.tool_name,
+                arguments=req.arguments or {},
+                requestor="assistant",
+            )
+        )
+        return {
+            "file": req.file,
+            "sim_index": req.sim_index,
+            "task_id": sim.task_id,
+            "domain": task.domain,
+            "tool_message": tool_msg.model_dump(mode="json"),
+        }
+
+    return app

--- a/src/vita/utils/llm_utils.py
+++ b/src/vita/utils/llm_utils.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import re
 import time
@@ -60,6 +61,36 @@ def get_response_cost(usage, model) -> float:
         return (prompt_price * num_prompt_token + completion_price * num_completion_token) / 1000000
     else:
         return 0.0
+
+
+def _redact_secret_value(value: Any) -> Any:
+    if not isinstance(value, str):
+        return "[redacted]"
+    if len(value) > 16:
+        return value[:10] + "...[redacted]"
+    return "[redacted]"
+
+
+def _redact_headers(headers: Optional[dict]) -> Optional[dict]:
+    if not isinstance(headers, dict):
+        return headers
+    redacted = copy.deepcopy(headers)
+    for key in list(redacted.keys()):
+        lk = str(key).lower()
+        if lk in ("authorization", "cookie", "x-api-key", "api-key"):
+            redacted[key] = _redact_secret_value(redacted[key])
+    return redacted
+
+
+def _redact_request_payload(payload: dict) -> dict:
+    redacted = copy.deepcopy(payload)
+    if isinstance(redacted.get("headers"), dict):
+        redacted["headers"] = _redact_headers(redacted["headers"])
+    for key in list(redacted.keys()):
+        lk = str(key).lower()
+        if lk in ("authorization", "cookie", "x-api-key", "api-key", "token"):
+            redacted[key] = _redact_secret_value(redacted[key])
+    return redacted
 
 
 def get_response_usage(response) -> Optional[dict]:
@@ -137,7 +168,7 @@ def to_claude_think_official(messages_formatted: list[dict], messages: list[Mess
             if signature:
                 messages_formatted[i]["signature"] = signature
 
-    except Exception as e:
+    except Exception:
         import traceback
         traceback.print_exc()
 
@@ -159,7 +190,7 @@ def to_deepseek_think_official(messages_formatted: list[dict], messages: list[Me
             if reasoning_content:
                 messages_formatted[i]["reasoning_content"] = reasoning_content
 
-    except Exception as e:
+    except Exception:
         import traceback
         traceback.print_exc()
 
@@ -224,6 +255,13 @@ def generate(
             data.update(models[model])
             data = kwargs_adapter(data, enable_think, messages)
             headers = models[model]["headers"]
+            request_snapshot = {
+                "source": "recorded",
+                "method": "POST",
+                "url": data.get("base_url"),
+                "headers": _redact_headers(headers),
+                "json": _redact_request_payload(data),
+            }
 
             max_retries = 3
             retry_delay = 1
@@ -256,6 +294,8 @@ def generate(
         cost = get_response_cost(usage, model)
         try:
             response = response['choices'][0]
+            if isinstance(response, dict):
+                response["_http_request"] = request_snapshot
         except (KeyError, IndexError, TypeError) as e:
             logger.error(f"Full response: {json.dumps(response, ensure_ascii=False, indent=2) if isinstance(response, dict) else response}")
             raise ValueError(f"Invalid API response format: {e}") from e

--- a/src/vita/utils/llm_utils.py
+++ b/src/vita/utils/llm_utils.py
@@ -267,10 +267,16 @@ def generate(
             retry_delay = 1
             for attempt in range(max_retries + 1):
                 try:
-                    response = requests.post(data["base_url"], json=data, headers=headers, timeout=(10, 600))
+                    http_response = requests.post(data["base_url"], json=data, headers=headers, timeout=(10, 600))
 
-                    if response.status_code != 500:
-                        response = response.json()
+                    if http_response.status_code != 500:
+                        response_status_code = http_response.status_code
+                        response = http_response.json()
+                        response_snapshot = {
+                            "source": "recorded",
+                            "status_code": response_status_code,
+                            "json": copy.deepcopy(response),
+                        }
                         break
 
                     if attempt < max_retries:
@@ -278,7 +284,7 @@ def generate(
                         time.sleep(retry_delay)
                         retry_delay *= 2
                     else:
-                        response.raise_for_status()
+                        http_response.raise_for_status()
 
                 except requests.exceptions.RequestException as e:
                     if attempt < max_retries:
@@ -296,6 +302,7 @@ def generate(
             response = response['choices'][0]
             if isinstance(response, dict):
                 response["_http_request"] = request_snapshot
+                response["_http_response"] = response_snapshot
         except (KeyError, IndexError, TypeError) as e:
             logger.error(f"Full response: {json.dumps(response, ensure_ascii=False, indent=2) if isinstance(response, dict) else response}")
             raise ValueError(f"Invalid API response format: {e}") from e

--- a/src/vita/utils/simulation_timeline.py
+++ b/src/vita/utils/simulation_timeline.py
@@ -1,0 +1,311 @@
+"""
+将一次 SimulationRun 的消息列表转为按顺序展示的 timeline 结构，供 Web 可视化使用。
+"""
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any, Optional
+
+from vita.data_model.message import (
+    AssistantMessage,
+    MultiToolMessage,
+    SystemMessage,
+    ToolMessage,
+    UserMessage,
+)
+from vita.data_model.simulation import Results, SimulationRun
+
+
+def _extract_reasoning(raw_data: Optional[dict]) -> Optional[str]:
+    """从 LLM 原始响应中提取思维链（助手与用户模拟器共用同一套字段约定）。"""
+    if not isinstance(raw_data, dict):
+        return None
+    msg = raw_data.get("message")
+    for key in ("reasoning_content", "reasoning"):
+        v = raw_data.get(key)
+        if isinstance(v, str) and v.strip():
+            return v
+        if isinstance(msg, dict):
+            v2 = msg.get(key)
+            if isinstance(v2, str) and v2.strip():
+                return v2
+    return None
+
+
+def _tool_calls_public(tc_list: Optional[list]) -> list[dict[str, Any]]:
+    if not tc_list:
+        return []
+    out = []
+    for tc in tc_list:
+        if hasattr(tc, "model_dump"):
+            d = tc.model_dump()
+        elif isinstance(tc, dict):
+            d = tc
+        else:
+            continue
+        out.append(
+            {
+                "id": d.get("id", ""),
+                "name": d.get("name", ""),
+                "requestor": d.get("requestor", "assistant"),
+                "arguments": d.get("arguments", {}),
+            }
+        )
+    return out
+
+
+def _message_public_snapshot(msg: Any) -> dict[str, Any]:
+    """用于“assistant 本轮接收信息”展示的简化快照。"""
+    base = {
+        "role": getattr(msg, "role", None),
+        "turn_idx": getattr(msg, "turn_idx", None),
+        "timestamp": getattr(msg, "timestamp", None),
+    }
+    if isinstance(msg, SystemMessage):
+        return {**base, "kind": "system", "content": msg.content}
+    if isinstance(msg, UserMessage):
+        return {
+            **base,
+            "kind": "user",
+            "content": msg.content,
+            "tool_calls": _tool_calls_public(msg.tool_calls),
+        }
+    if isinstance(msg, AssistantMessage):
+        return {
+            **base,
+            "kind": "assistant",
+            "content": msg.content,
+            "tool_calls": _tool_calls_public(msg.tool_calls),
+        }
+    if isinstance(msg, ToolMessage):
+        return {
+            **base,
+            "kind": "tool",
+            "tool_call_id": msg.id,
+            "tool_name": msg.name,
+            "requestor": msg.requestor,
+            "content": msg.content,
+            "error": msg.error,
+        }
+    if isinstance(msg, MultiToolMessage):
+        return {
+            **base,
+            "kind": "multi_tool",
+            "tool_results": [
+                {
+                    "tool_call_id": tm.id,
+                    "tool_name": tm.name,
+                    "requestor": tm.requestor,
+                    "content": tm.content,
+                    "error": tm.error,
+                }
+                for tm in msg.tool_messages
+            ],
+        }
+    return {**base, "kind": "unknown", "repr": repr(msg)}
+
+
+def build_timeline_from_simulation(simulation: SimulationRun) -> list[dict[str, Any]]:
+    """
+    按 messages 顺序生成 timeline 条目；assistant 拆出思维链、正文、工具调用；tool 含结果与错误标记。
+    """
+    entries: list[dict[str, Any]] = []
+    seq = 0
+    for msg in simulation.messages:
+        seq += 1
+        base = {
+            "seq": seq,
+            "turn_idx": getattr(msg, "turn_idx", None),
+            "timestamp": getattr(msg, "timestamp", None),
+        }
+        if isinstance(msg, SystemMessage):
+            entries.append(
+                {
+                    **base,
+                    "kind": "system",
+                    "role": "system",
+                    "content": msg.content,
+                }
+            )
+        elif isinstance(msg, UserMessage):
+            user_reasoning = _extract_reasoning(
+                msg.raw_data if isinstance(msg.raw_data, dict) else None
+            )
+            received_messages = [
+                _message_public_snapshot(m) for m in simulation.messages[: seq - 1]
+            ]
+            entries.append(
+                {
+                    **base,
+                    "kind": "user",
+                    "role": "user",
+                    "reasoning": user_reasoning,
+                    "content": msg.content,
+                    "tool_calls": _tool_calls_public(msg.tool_calls),
+                    "usage": msg.usage,
+                    "cost": msg.cost,
+                    "raw_data": msg.raw_data,
+                    "user_received_context": received_messages,
+                }
+            )
+        elif isinstance(msg, AssistantMessage):
+            reasoning = _extract_reasoning(
+                msg.raw_data if isinstance(msg.raw_data, dict) else None
+            )
+            received_messages = [
+                _message_public_snapshot(m) for m in simulation.messages[: seq - 1]
+            ]
+            entries.append(
+                {
+                    **base,
+                    "kind": "assistant",
+                    "role": "assistant",
+                    "reasoning": reasoning,
+                    "content": msg.content,
+                    "tool_calls": _tool_calls_public(msg.tool_calls),
+                    "usage": msg.usage,
+                    "cost": msg.cost,
+                    "raw_data": msg.raw_data,
+                    # 近似重建：assistant 在该轮生成前可见的历史消息（按顺序）
+                    "assistant_received_context": received_messages,
+                }
+            )
+        elif isinstance(msg, ToolMessage):
+            entries.append(
+                {
+                    **base,
+                    "kind": "tool",
+                    "role": "tool",
+                    "tool_call_id": msg.id,
+                    "tool_name": msg.name,
+                    "requestor": msg.requestor,
+                    "content": msg.content,
+                    "error": msg.error,
+                }
+            )
+        elif isinstance(msg, MultiToolMessage):
+            subs = []
+            for tm in msg.tool_messages:
+                subs.append(
+                    {
+                        "tool_call_id": tm.id,
+                        "tool_name": tm.name,
+                        "requestor": tm.requestor,
+                        "content": tm.content,
+                        "error": tm.error,
+                    }
+                )
+            entries.append(
+                {
+                    **base,
+                    "kind": "multi_tool",
+                    "role": "tool",
+                    "tool_results": subs,
+                }
+            )
+        else:
+            entries.append(
+                {
+                    **base,
+                    "kind": "unknown",
+                    "role": getattr(msg, "role", None),
+                    "repr": repr(msg),
+                }
+            )
+    return entries
+
+
+def _redact_llm_args_for_display(llm_args: Optional[dict]) -> Optional[dict]:
+    """脱敏后展示 llm_args（避免把 Authorization 等原样打到页面上）。"""
+    if not llm_args:
+        return None
+    d = copy.deepcopy(llm_args)
+    headers = d.get("headers")
+    if isinstance(headers, dict):
+        for key in list(headers.keys()):
+            lk = str(key).lower()
+            if lk in ("authorization", "cookie", "x-api-key", "api-key"):
+                val = headers[key]
+                if isinstance(val, str) and len(val) > 16:
+                    headers[key] = val[:10] + "…（已隐藏）"
+                else:
+                    headers[key] = "（已隐藏）"
+    return d
+
+
+def build_user_simulator_profile(results: Results, task_id: str) -> dict[str, Any]:
+    """
+    汇总 User Simulator 的角色设定来源：
+    - results.info.user_info：实现类型、所用 LLM、全局用户模拟器说明模板
+    - 对应 Task：user_scenario（人设/情境）、instructions（本任务要用户通过对话传达给智能体的指令）
+    - 与运行时一致：用 str(user_profile) + instructions 对模板做 .format，得到实际 system prompt
+    """
+    ui = results.info.user_info
+    base: dict[str, Any] = {
+        "implementation": ui.implementation,
+        "llm": ui.llm,
+        "llm_args": _redact_llm_args_for_display(ui.llm_args),
+        "global_simulation_guidelines_template": ui.global_simulation_guidelines,
+    }
+    task = next((t for t in results.tasks if t.id == task_id), None)
+    if task is None:
+        base["task_found"] = False
+        base["note"] = f"未在 results.tasks 中找到 task_id={task_id}，仅展示 info.user_info。"
+        return base
+
+    base["task_found"] = True
+    base["task_id"] = task.id
+    base["domain"] = task.domain
+    base["user_scenario"] = task.user_scenario.model_dump(mode="json")
+    base["instructions"] = task.instructions
+
+    # 与 UserSimulator.system_prompt / run.py 中 UserConstructor 一致
+    persona_runtime = str(task.user_scenario.user_profile)
+    instructions_runtime = str(task.instructions)
+    base["persona_runtime_string"] = persona_runtime
+
+    tpl = ui.global_simulation_guidelines or ""
+    rendered: Optional[str] = None
+    render_error: Optional[str] = None
+    if tpl:
+        try:
+            rendered = tpl.format(
+                persona=persona_runtime,
+                instructions=instructions_runtime,
+            )
+        except (KeyError, ValueError) as e:
+            render_error = f"{type(e).__name__}: {e}"
+    base["rendered_user_system_prompt"] = rendered
+    base["rendered_system_prompt_error"] = render_error
+
+    return base
+
+
+def simulation_run_summary(simulation: SimulationRun) -> dict[str, Any]:
+    return {
+        "id": simulation.id,
+        "task_id": simulation.task_id,
+        "trial": simulation.trial,
+        "seed": simulation.seed,
+        "termination_reason": str(simulation.termination_reason),
+        "start_time": simulation.start_time,
+        "end_time": simulation.end_time,
+        "duration": simulation.duration,
+        "agent_cost": simulation.agent_cost,
+        "user_cost": simulation.user_cost,
+        "reward": simulation.reward_info.reward
+        if simulation.reward_info
+        else None,
+        "message_count": len(simulation.messages),
+    }
+
+
+def format_json_for_display(obj: Any, max_chars: int = 120_000) -> str:
+    try:
+        s = json.dumps(obj, ensure_ascii=False, indent=2)
+    except TypeError:
+        s = str(obj)
+    if len(s) > max_chars:
+        return s[:max_chars] + f"\n\n…（已截断，共 {len(s)} 字符）"
+    return s

--- a/src/vita/utils/simulation_timeline.py
+++ b/src/vita/utils/simulation_timeline.py
@@ -55,6 +55,38 @@ def _tool_calls_public(tc_list: Optional[list]) -> list[dict[str, Any]]:
     return out
 
 
+def _redact_secret_value(value: Any) -> Any:
+    if not isinstance(value, str):
+        return "（已隐藏）"
+    if len(value) > 16:
+        return value[:10] + "…（已隐藏）"
+    return "（已隐藏）"
+
+
+def _redact_headers_for_display(headers: Optional[dict]) -> Optional[dict]:
+    if not isinstance(headers, dict):
+        return headers
+    redacted = copy.deepcopy(headers)
+    for key in list(redacted.keys()):
+        lk = str(key).lower()
+        if lk in ("authorization", "cookie", "x-api-key", "api-key"):
+            redacted[key] = _redact_secret_value(redacted[key])
+    return redacted
+
+
+def _redact_request_json_for_display(payload: Optional[dict]) -> Optional[dict]:
+    if not isinstance(payload, dict):
+        return payload
+    redacted = copy.deepcopy(payload)
+    if isinstance(redacted.get("headers"), dict):
+        redacted["headers"] = _redact_headers_for_display(redacted["headers"])
+    for key in list(redacted.keys()):
+        lk = str(key).lower()
+        if lk in ("authorization", "cookie", "x-api-key", "api-key", "token"):
+            redacted[key] = _redact_secret_value(redacted[key])
+    return redacted
+
+
 def _message_public_snapshot(msg: Any) -> dict[str, Any]:
     """用于“assistant 本轮接收信息”展示的简化快照。"""
     base = {
@@ -106,7 +138,75 @@ def _message_public_snapshot(msg: Any) -> dict[str, Any]:
     return {**base, "kind": "unknown", "repr": repr(msg)}
 
 
-def build_timeline_from_simulation(simulation: SimulationRun) -> list[dict[str, Any]]:
+def _recorded_http_request(raw_data: Optional[dict]) -> Optional[dict[str, Any]]:
+    if not isinstance(raw_data, dict):
+        return None
+    request = raw_data.get("_http_request") or raw_data.get("http_request")
+    if not isinstance(request, dict):
+        return None
+    redacted = copy.deepcopy(request)
+    redacted["source"] = redacted.get("source") or "recorded"
+    redacted["headers"] = _redact_headers_for_display(redacted.get("headers"))
+    redacted["json"] = _redact_request_json_for_display(redacted.get("json"))
+    return redacted
+
+
+def _llm_info_for_role(results: Optional[Results], role: str):
+    if results is None:
+        return None
+    if role == "user":
+        return results.info.user_info
+    if role == "assistant":
+        return results.info.agent_info
+    return None
+
+
+def _reconstructed_http_request(
+    results: Optional[Results],
+    role: str,
+    received_messages: list[dict[str, Any]],
+) -> Optional[dict[str, Any]]:
+    info = _llm_info_for_role(results, role)
+    if info is None:
+        return None
+    llm_args = _redact_request_json_for_display(getattr(info, "llm_args", None)) or {}
+    request_json = copy.deepcopy(llm_args)
+    base_url = request_json.pop("base_url", None)
+    headers = request_json.pop("headers", None)
+    request_json.update(
+        {
+            "model": getattr(info, "llm", None),
+            "messages": received_messages,
+            "stream": False,
+        }
+    )
+    if role == "assistant":
+        request_json["tools"] = "not stored in Results; available at runtime"
+        request_json["tool_choice"] = "auto when tools are supplied"
+    return {
+        "source": "reconstructed",
+        "method": "POST",
+        "url": base_url,
+        "headers": _redact_headers_for_display(headers),
+        "json": request_json,
+        "note": "The original HTTP request was not stored in this Results file; this view is reconstructed from saved context and run metadata.",
+    }
+
+
+def _http_request_snapshot(
+    results: Optional[Results],
+    role: str,
+    received_messages: list[dict[str, Any]],
+    raw_data: Optional[dict],
+) -> Optional[dict[str, Any]]:
+    return _recorded_http_request(raw_data) or _reconstructed_http_request(
+        results, role, received_messages
+    )
+
+
+def build_timeline_from_simulation(
+    simulation: SimulationRun, results: Optional[Results] = None
+) -> list[dict[str, Any]]:
     """
     按 messages 顺序生成 timeline 条目；assistant 拆出思维链、正文、工具调用；tool 含结果与错误标记。
     """
@@ -145,6 +245,9 @@ def build_timeline_from_simulation(simulation: SimulationRun) -> list[dict[str, 
                     "tool_calls": _tool_calls_public(msg.tool_calls),
                     "usage": msg.usage,
                     "cost": msg.cost,
+                    "http_request": _http_request_snapshot(
+                        results, "user", received_messages, msg.raw_data
+                    ),
                     "raw_data": msg.raw_data,
                     "user_received_context": received_messages,
                 }
@@ -166,6 +269,9 @@ def build_timeline_from_simulation(simulation: SimulationRun) -> list[dict[str, 
                     "tool_calls": _tool_calls_public(msg.tool_calls),
                     "usage": msg.usage,
                     "cost": msg.cost,
+                    "http_request": _http_request_snapshot(
+                        results, "assistant", received_messages, msg.raw_data
+                    ),
                     "raw_data": msg.raw_data,
                     # 近似重建：assistant 在该轮生成前可见的历史消息（按顺序）
                     "assistant_received_context": received_messages,
@@ -221,16 +327,7 @@ def _redact_llm_args_for_display(llm_args: Optional[dict]) -> Optional[dict]:
     if not llm_args:
         return None
     d = copy.deepcopy(llm_args)
-    headers = d.get("headers")
-    if isinstance(headers, dict):
-        for key in list(headers.keys()):
-            lk = str(key).lower()
-            if lk in ("authorization", "cookie", "x-api-key", "api-key"):
-                val = headers[key]
-                if isinstance(val, str) and len(val) > 16:
-                    headers[key] = val[:10] + "…（已隐藏）"
-                else:
-                    headers[key] = "（已隐藏）"
+    d["headers"] = _redact_headers_for_display(d.get("headers"))
     return d
 
 

--- a/src/vita/utils/simulation_timeline.py
+++ b/src/vita/utils/simulation_timeline.py
@@ -151,6 +151,19 @@ def _recorded_http_request(raw_data: Optional[dict]) -> Optional[dict[str, Any]]
     return redacted
 
 
+def _recorded_http_response(raw_data: Optional[dict]) -> Optional[dict[str, Any]]:
+    if not isinstance(raw_data, dict):
+        return None
+    response = raw_data.get("_http_response") or raw_data.get("http_response")
+    if isinstance(response, dict):
+        return copy.deepcopy(response)
+    return {
+        "source": "saved_choice_only",
+        "json": copy.deepcopy(raw_data),
+        "note": "This Results file stores only the selected response choice, not the full HTTP response object.",
+    }
+
+
 def _llm_info_for_role(results: Optional[Results], role: str):
     if results is None:
         return None
@@ -204,6 +217,10 @@ def _http_request_snapshot(
     )
 
 
+def _http_response_snapshot(raw_data: Optional[dict]) -> Optional[dict[str, Any]]:
+    return _recorded_http_response(raw_data)
+
+
 def build_timeline_from_simulation(
     simulation: SimulationRun, results: Optional[Results] = None
 ) -> list[dict[str, Any]]:
@@ -248,6 +265,7 @@ def build_timeline_from_simulation(
                     "http_request": _http_request_snapshot(
                         results, "user", received_messages, msg.raw_data
                     ),
+                    "http_response": _http_response_snapshot(msg.raw_data),
                     "raw_data": msg.raw_data,
                     "user_received_context": received_messages,
                 }
@@ -272,6 +290,7 @@ def build_timeline_from_simulation(
                     "http_request": _http_request_snapshot(
                         results, "assistant", received_messages, msg.raw_data
                     ),
+                    "http_response": _http_response_snapshot(msg.raw_data),
                     "raw_data": msg.raw_data,
                     # 近似重建：assistant 在该轮生成前可见的历史消息（按顺序）
                     "assistant_received_context": received_messages,

--- a/src/vita/utils/task_sorting.py
+++ b/src/vita/utils/task_sorting.py
@@ -1,0 +1,37 @@
+import re
+from typing import Any
+
+
+def task_id_sort_key(task_id: Any) -> tuple:
+    """Natural ascending key; digit-leading ids sort before letter-leading (e.g. 10807012 before A0812003)."""
+    s = str(task_id)
+    if s[:1].isdigit():
+        leading = 0
+    elif s[:1].isalpha():
+        leading = 1
+    else:
+        leading = 2
+    parts = re.split(r"(\d+)", s)
+    key = []
+    for part in parts:
+        if not part:
+            continue
+        if part.isdigit():
+            key.append((0, int(part)))
+        else:
+            key.append((1, part.lower()))
+    return (leading,) + tuple(key)
+
+
+def simulation_sort_key(simulation: Any) -> tuple:
+    trial = getattr(simulation, "trial", None)
+    seed = getattr(simulation, "seed", None)
+    return (
+        task_id_sort_key(getattr(simulation, "task_id", "")),
+        trial if trial is not None else -1,
+        seed if seed is not None else -1,
+    )
+
+
+def task_sort_key(task: Any) -> tuple:
+    return (task_id_sort_key(getattr(task, "id", "")),)

--- a/src/vita/web/dashboard.html
+++ b/src/vita/web/dashboard.html
@@ -404,6 +404,12 @@
         cursor: default;
       }
 
+      .active-filter {
+        background: var(--coal) !important;
+        color: #fffaf0 !important;
+        border-color: var(--coal) !important;
+      }
+
       .timeline-preview {
         display: grid;
         gap: 8px;
@@ -551,6 +557,7 @@
         resultRunPages: {},
         resultRuns: {},
         resultRowsPerPage: 12,
+        resultRewardFilter: "all",
         expandedSimulation: "",
         timelines: {},
         autoRefresh: true,
@@ -823,7 +830,12 @@
           <section class="section">
             <div class="section-head">
               <h3>Result Files</h3>
-              <span class="mono">${files.length} files</span>
+              <div class="links">
+                <button id="rewardFilterBtn" class="${state.resultRewardFilter === "non_full" ? "active-filter" : ""}" title="只看 reward 未满分的 simulations">
+                  ${state.resultRewardFilter === "non_full" ? "non-full reward on" : "non-full reward"}
+                </button>
+                <span class="mono">${files.length} files</span>
+              </div>
             </div>
             <table class="table">
               <thead>
@@ -897,8 +909,13 @@
         }
         const total = cache.total_count || cache.simulation_count || 0;
         const pageCount = Math.max(1, Math.ceil(total / state.resultRowsPerPage));
+        const filterLabel =
+          cache.reward_filter === "non_full"
+            ? `non-full reward · ${total}/${cache.unfiltered_count || 0}`
+            : `${total} simulations`;
         return `
           <div class="result-panel">
+            <div class="mono" style="margin-bottom:10px">${escapeHtml(filterLabel)}</div>
             <table class="nested-table">
               <thead>
                 <tr>
@@ -1046,6 +1063,19 @@
             loadResultRuns(file);
           });
         });
+
+        const rewardFilterBtn = document.getElementById("rewardFilterBtn");
+        if (rewardFilterBtn) {
+          rewardFilterBtn.addEventListener("click", () => {
+            state.resultRewardFilter =
+              state.resultRewardFilter === "non_full" ? "all" : "non_full";
+            state.resultRuns = {};
+            state.resultRunPages = {};
+            state.expandedSimulation = "";
+            renderContent();
+            if (state.expandedResultFile) loadResultRuns(state.expandedResultFile);
+          });
+        }
       }
 
       function simulationKey(file, simIndex) {
@@ -1063,6 +1093,9 @@
           offset: String(page * state.resultRowsPerPage),
           limit: String(state.resultRowsPerPage),
         });
+        if (state.resultRewardFilter === "non_full") {
+          params.set("reward_filter", "non_full");
+        }
         try {
           const res = await fetch(`/api/simulation-runs?${params.toString()}`);
           if (!res.ok) throw new Error(await res.text());

--- a/src/vita/web/dashboard.html
+++ b/src/vita/web/dashboard.html
@@ -1001,6 +1001,7 @@
           <details>
             <summary>${escapeHtml(title)}</summary>
             ${renderHttpRequest(entry.http_request)}
+            ${renderHttpResponse(entry.http_response)}
             <pre>${escapeHtml(body || "")}</pre>
           </details>
         `;
@@ -1013,6 +1014,18 @@
           <details>
             <summary>${escapeHtml(label)}</summary>
             <pre>${escapeHtml(JSON.stringify(request, null, 2))}</pre>
+          </details>
+        `;
+      }
+
+      function renderHttpResponse(response) {
+        if (!response) return "";
+        const label =
+          response.source === "saved_choice_only" ? "saved assistant/user return" : "raw HTTP response";
+        return `
+          <details>
+            <summary>${escapeHtml(label)}</summary>
+            <pre>${escapeHtml(JSON.stringify(response, null, 2))}</pre>
           </details>
         `;
       }

--- a/src/vita/web/dashboard.html
+++ b/src/vita/web/dashboard.html
@@ -1,0 +1,1137 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VitaBench 看板</title>
+    <style>
+      :root {
+        --paper: #f7f3ea;
+        --ink: #202124;
+        --muted: #6f6a60;
+        --line: #d8d0c1;
+        --panel: #fffaf0;
+        --panel-strong: #f0e6d3;
+        --coal: #252a2e;
+        --green: #1d7a5c;
+        --amber: #a05d00;
+        --red: #b3261e;
+        --blue: #2368a2;
+        --violet: #7b4aa0;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          "Avenir Next", "Gill Sans", "Trebuchet MS", "PingFang SC",
+          "Microsoft YaHei", sans-serif;
+      }
+
+      button,
+      input {
+        font: inherit;
+      }
+
+      .shell {
+        min-height: 100vh;
+        display: grid;
+        grid-template-columns: 340px 1fr;
+      }
+
+      .rail {
+        border-right: 1px solid var(--line);
+        background: #eee4d2;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .brand {
+        padding: 18px 18px 14px;
+        border-bottom: 1px solid var(--line);
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      .brand h1 {
+        margin: 0;
+        font-size: 21px;
+        letter-spacing: 0;
+      }
+
+      .clock {
+        color: var(--muted);
+        font-size: 12px;
+        white-space: nowrap;
+      }
+
+      .rail-tools {
+        padding: 12px 14px;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 8px;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .rail-tools input {
+        width: 100%;
+        border: 1px solid var(--line);
+        background: #fffaf0;
+        color: var(--ink);
+        border-radius: 6px;
+        padding: 9px 10px;
+        min-width: 0;
+      }
+
+      .icon-btn {
+        border: 1px solid var(--line);
+        background: var(--coal);
+        color: #fffaf0;
+        border-radius: 6px;
+        width: 38px;
+        height: 38px;
+        cursor: pointer;
+      }
+
+      .runs {
+        overflow: auto;
+        padding: 10px;
+      }
+
+      .run-item {
+        width: 100%;
+        display: grid;
+        gap: 8px;
+        text-align: left;
+        border: 1px solid transparent;
+        border-radius: 8px;
+        padding: 10px;
+        background: transparent;
+        cursor: pointer;
+        color: var(--ink);
+      }
+
+      .run-item:hover {
+        background: #f6eddc;
+      }
+
+      .run-item.active {
+        background: var(--panel);
+        border-color: #bfae91;
+      }
+
+      .run-title {
+        font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.35;
+        overflow-wrap: anywhere;
+      }
+
+      .run-meta {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        border: 1px solid currentColor;
+        border-radius: 999px;
+        padding: 2px 8px;
+        font-size: 11px;
+        text-transform: uppercase;
+        white-space: nowrap;
+      }
+
+      .dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 99px;
+        background: currentColor;
+        display: inline-block;
+      }
+
+      .running {
+        color: var(--blue);
+      }
+
+      .complete {
+        color: var(--green);
+      }
+
+      .failed {
+        color: var(--red);
+      }
+
+      .partial {
+        color: var(--violet);
+      }
+
+      .pending {
+        color: var(--amber);
+      }
+
+      .main {
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .topbar {
+        min-height: 64px;
+        border-bottom: 1px solid var(--line);
+        background: var(--panel);
+        padding: 13px 18px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+      }
+
+      .topbar-title {
+        min-width: 0;
+      }
+
+      .topbar-title h2 {
+        margin: 0;
+        font-size: 18px;
+        overflow-wrap: anywhere;
+      }
+
+      .topbar-title p {
+        margin: 3px 0 0;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .links {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      .links a,
+      .links button {
+        border: 1px solid var(--line);
+        background: #fffaf0;
+        color: var(--ink);
+        text-decoration: none;
+        border-radius: 6px;
+        padding: 8px 10px;
+        cursor: pointer;
+        font-size: 13px;
+      }
+
+      .content {
+        padding: 18px;
+        display: grid;
+        gap: 16px;
+      }
+
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(140px, 1fr));
+        gap: 10px;
+      }
+
+      .metric {
+        border: 1px solid var(--line);
+        background: var(--panel);
+        border-radius: 8px;
+        padding: 12px;
+        min-height: 86px;
+      }
+
+      .metric-label {
+        color: var(--muted);
+        font-size: 12px;
+        margin-bottom: 8px;
+      }
+
+      .metric-value {
+        font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+        font-size: 22px;
+        line-height: 1.1;
+      }
+
+      .progress-track {
+        height: 8px;
+        width: 100%;
+        border-radius: 99px;
+        background: #e4dac8;
+        overflow: hidden;
+        margin-top: 10px;
+      }
+
+      .progress-bar {
+        height: 100%;
+        background: linear-gradient(90deg, var(--green), var(--blue));
+        width: 0;
+      }
+
+      .section {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+        overflow: hidden;
+      }
+
+      .section-head {
+        min-height: 42px;
+        padding: 11px 12px;
+        border-bottom: 1px solid var(--line);
+        background: var(--panel-strong);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      .section-head h3 {
+        margin: 0;
+        font-size: 14px;
+      }
+
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      .table th,
+      .table td {
+        border-bottom: 1px solid #e7decf;
+        padding: 10px 12px;
+        vertical-align: middle;
+        text-align: left;
+        font-size: 13px;
+      }
+
+      .table th {
+        color: var(--muted);
+        font-weight: 600;
+        background: #faf2e4;
+      }
+
+      .split-row {
+        cursor: pointer;
+      }
+
+      .split-row:hover {
+        background: #fff5e5;
+      }
+
+      .mono {
+        font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+      }
+
+      .log-panel {
+        border-top: 1px solid var(--line);
+        background: #202124;
+        color: #f2eadf;
+      }
+
+      .result-row,
+      .simulation-row {
+        cursor: pointer;
+      }
+
+      .result-row:hover,
+      .simulation-row:hover {
+        background: #fff5e5;
+      }
+
+      .result-panel {
+        border-top: 1px solid var(--line);
+        background: #fff8eb;
+        padding: 12px;
+      }
+
+      .nested-table {
+        width: 100%;
+        border-collapse: collapse;
+        background: #fffdf7;
+        border: 1px solid #e7decf;
+      }
+
+      .nested-table th,
+      .nested-table td {
+        border-bottom: 1px solid #ece2d1;
+        padding: 8px 10px;
+        text-align: left;
+        vertical-align: top;
+        font-size: 12px;
+      }
+
+      .pager {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 8px;
+        padding: 10px 12px;
+        border-top: 1px solid #e7decf;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .pager button,
+      .small-link {
+        border: 1px solid var(--line);
+        background: #fffaf0;
+        color: var(--ink);
+        border-radius: 6px;
+        padding: 6px 9px;
+        cursor: pointer;
+        text-decoration: none;
+        font-size: 12px;
+      }
+
+      .pager button:disabled {
+        opacity: 0.45;
+        cursor: default;
+      }
+
+      .timeline-preview {
+        display: grid;
+        gap: 8px;
+        padding: 10px;
+        background: #202124;
+        color: #f2eadf;
+        border-radius: 8px;
+      }
+
+      .timeline-preview details {
+        border: 1px solid #3b3f43;
+        border-radius: 7px;
+        background: #17191b;
+        padding: 7px 9px;
+      }
+
+      .timeline-preview summary {
+        cursor: pointer;
+        color: #d6d0c7;
+        font-size: 12px;
+      }
+
+      .log-tools {
+        padding: 10px 12px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        border-bottom: 1px solid #3b3f43;
+      }
+
+      .log-tools input {
+        width: 92px;
+        border: 1px solid #555b60;
+        background: #111315;
+        color: #f2eadf;
+        border-radius: 6px;
+        padding: 7px 8px;
+      }
+
+      .log-tools button {
+        border: 1px solid #5b625f;
+        background: #29302c;
+        color: #f2eadf;
+        border-radius: 6px;
+        padding: 7px 10px;
+        cursor: pointer;
+      }
+
+      pre {
+        margin: 0;
+        padding: 12px;
+        max-height: 56vh;
+        overflow: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+        font-size: 12px;
+        line-height: 1.45;
+      }
+
+      .empty {
+        padding: 28px;
+        color: var(--muted);
+        text-align: center;
+      }
+
+      @media (max-width: 980px) {
+        .shell {
+          grid-template-columns: 1fr;
+        }
+
+        .rail {
+          border-right: 0;
+          border-bottom: 1px solid var(--line);
+          max-height: 38vh;
+        }
+
+        .metric-grid {
+          grid-template-columns: repeat(2, minmax(140px, 1fr));
+        }
+
+        .topbar {
+          align-items: flex-start;
+          flex-direction: column;
+        }
+      }
+
+      @media (max-width: 620px) {
+        .metric-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .table {
+          min-width: 760px;
+        }
+
+        .section {
+          overflow-x: auto;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="shell">
+      <aside class="rail">
+        <div class="brand">
+          <h1>VitaBench</h1>
+          <span class="clock" id="clock">--:--:--</span>
+        </div>
+        <div class="rail-tools">
+          <input id="runFilter" placeholder="filter runs" />
+          <button class="icon-btn" id="refreshBtn" title="刷新">↻</button>
+        </div>
+        <div class="runs" id="runs"></div>
+      </aside>
+
+      <main class="main">
+        <header class="topbar">
+          <div class="topbar-title">
+            <h2 id="runTitle">选择实验</h2>
+            <p id="runSubtitle">data/logs/benchmark_runs · data/simulations/benchmark_runs</p>
+          </div>
+          <div class="links">
+            <button id="autoBtn" title="自动刷新">auto on</button>
+            <a href="/trajectory">trajectory</a>
+            <a href="/events">events</a>
+          </div>
+        </header>
+
+        <div class="content" id="content">
+          <div class="empty">暂无实验</div>
+        </div>
+      </main>
+    </div>
+
+    <script>
+      const state = {
+        runs: [],
+        detail: null,
+        selectedRun: new URLSearchParams(location.search).get("run") || "",
+        expandedSplit: "",
+        resultFilePage: 0,
+        resultFilesPerPage: 5,
+        expandedResultFile: "",
+        resultRunPages: {},
+        resultRuns: {},
+        resultRowsPerPage: 12,
+        expandedSimulation: "",
+        timelines: {},
+        autoRefresh: true,
+        logLines: 300,
+      };
+
+      const statusText = {
+        running: "running",
+        complete: "complete",
+        failed: "failed",
+        partial: "partial",
+        pending: "pending",
+      };
+
+      function escapeHtml(value) {
+        return String(value ?? "")
+          .replaceAll("&", "&amp;")
+          .replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;")
+          .replaceAll('"', "&quot;")
+          .replaceAll("'", "&#039;");
+      }
+
+      function fmtPct(value) {
+        return `${Math.round((Number(value) || 0) * 100)}%`;
+      }
+
+      function fmtTime(ts) {
+        if (!ts) return "-";
+        return new Date(ts * 1000).toLocaleString();
+      }
+
+      function fmtAge(seconds) {
+        if (seconds == null) return "-";
+        if (seconds < 60) return `${Math.floor(seconds)}s`;
+        if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+        return `${(seconds / 3600).toFixed(1)}h`;
+      }
+
+      function fmtSize(bytes) {
+        if (!bytes) return "-";
+        if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+        return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+      }
+
+      function statusBadge(status) {
+        const cls = statusText[status] || "pending";
+        return `<span class="status ${cls}"><span class="dot"></span>${cls}</span>`;
+      }
+
+      function selectedRun() {
+        if (state.detail?.run_name === state.selectedRun) return state.detail;
+        return state.runs.find((run) => run.run_name === state.selectedRun);
+      }
+
+      function trajectoryHref(file, simIndex = "") {
+        const params = new URLSearchParams({ file });
+        if (simIndex !== "") params.set("sim_index", String(simIndex));
+        return `/trajectory?${params.toString()}`;
+      }
+
+      function resultFilesForRun(run) {
+        const seen = new Set();
+        return (run.splits || [])
+          .filter((split) => split.result_view_file)
+          .map((split) => ({
+            file: split.result_view_file,
+            split: split.label,
+            status: split.status,
+            completed: split.completed,
+            expected: split.expected,
+            progress: split.progress,
+            metrics: split.metrics || {},
+            size: split.result_size,
+            mtime: split.result_mtime || split.mtime,
+          }))
+          .filter((row) => {
+            if (seen.has(row.file)) return false;
+            seen.add(row.file);
+            return true;
+          });
+      }
+
+      async function loadRuns() {
+        const res = await fetch("/api/benchmark-runs?limit=120");
+        if (!res.ok) throw new Error(await res.text());
+        const data = await res.json();
+        state.runs = data.runs || [];
+        if (!state.selectedRun && state.runs.length) {
+          state.selectedRun = state.runs[0].run_name;
+        }
+        if (state.selectedRun && !selectedRun() && state.runs.length) {
+          state.selectedRun = state.runs[0].run_name;
+        }
+        if (state.selectedRun) {
+          await loadSelectedRunDetail();
+        }
+        renderRuns();
+        renderContent();
+        if (state.expandedSplit) {
+          loadLog();
+        }
+      }
+
+      async function loadSelectedRunDetail() {
+        const params = new URLSearchParams({ run_name: state.selectedRun });
+        const res = await fetch(`/api/benchmark-runs?${params.toString()}`);
+        if (!res.ok) throw new Error(await res.text());
+        const data = await res.json();
+        state.detail = data.runs?.[0] || null;
+      }
+
+      function renderRuns() {
+        const filter = document.getElementById("runFilter").value.trim().toLowerCase();
+        const runs = document.getElementById("runs");
+        const filtered = state.runs.filter((run) =>
+          run.run_name.toLowerCase().includes(filter),
+        );
+        runs.innerHTML =
+          filtered
+            .map(
+              (run) => `
+                <button class="run-item ${run.run_name === state.selectedRun ? "active" : ""}" data-run="${escapeHtml(run.run_name)}">
+                  <div class="run-title">${escapeHtml(run.run_name)}</div>
+                  <div class="run-meta">
+                    ${statusBadge(run.status)}
+                    <span>${escapeHtml(fmtPct(run.progress))} · ${escapeHtml(fmtAge(run.age_seconds))}</span>
+                  </div>
+                  <div class="progress-track"><div class="progress-bar" style="width:${escapeHtml(fmtPct(run.progress))}"></div></div>
+                </button>
+              `,
+            )
+            .join("") || `<div class="empty">No runs</div>`;
+
+        runs.querySelectorAll(".run-item").forEach((button) => {
+          button.addEventListener("click", () => {
+            state.selectedRun = button.dataset.run;
+            state.expandedSplit = "";
+            state.resultFilePage = 0;
+            state.expandedResultFile = "";
+            state.expandedSimulation = "";
+            state.detail = null;
+            const url = new URL(location.href);
+            url.searchParams.set("run", state.selectedRun);
+            history.replaceState(null, "", url);
+            loadRuns().catch(console.error);
+          });
+        });
+      }
+
+      function renderContent() {
+        const run = selectedRun();
+        const content = document.getElementById("content");
+        document.getElementById("runTitle").textContent = run?.run_name || "选择实验";
+        document.getElementById("runSubtitle").textContent = run
+          ? `last update ${fmtTime(run.last_update)}`
+          : "data/logs/benchmark_runs · data/simulations/benchmark_runs";
+
+        if (!run) {
+          content.innerHTML = `<div class="empty">暂无实验</div>`;
+          return;
+        }
+
+        const visibleSplits = run.splits.filter(
+          (split) => split.status !== "pending" || split.log_file || split.result_file,
+        );
+
+        content.innerHTML = `
+          <section class="metric-grid">
+            <div class="metric">
+              <div class="metric-label">run status</div>
+              <div>${statusBadge(run.status)}</div>
+            </div>
+            <div class="metric">
+              <div class="metric-label">samples</div>
+              <div class="metric-value">${run.completed_samples}/${run.expected_samples}</div>
+              <div class="progress-track"><div class="progress-bar" style="width:${fmtPct(run.progress)}"></div></div>
+            </div>
+            <div class="metric">
+              <div class="metric-label">splits</div>
+              <div class="metric-value">${run.completed_splits}/${run.total_splits}</div>
+            </div>
+            <div class="metric">
+              <div class="metric-label">last update</div>
+              <div class="metric-value">${escapeHtml(fmtAge(run.age_seconds))}</div>
+            </div>
+          </section>
+
+          <section class="section">
+            <div class="section-head">
+              <h3>Splits</h3>
+              <span class="mono">${escapeHtml(run.run_name)}</span>
+            </div>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>split</th>
+                  <th>status</th>
+                  <th>progress</th>
+                  <th>avg reward</th>
+                  <th>pass^1</th>
+                  <th>result</th>
+                  <th>log</th>
+                  <th>updated</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${
+                  visibleSplits
+                    .map(
+                      (split) => `
+                        <tr class="split-row" data-split="${escapeHtml(split.key)}">
+                          <td class="mono">${escapeHtml(split.label)}</td>
+                          <td>${statusBadge(split.status)}</td>
+                          <td>
+                            <span class="mono">${split.completed}/${split.expected}</span>
+                            <div class="progress-track"><div class="progress-bar" style="width:${fmtPct(split.progress)}"></div></div>
+                          </td>
+                          <td class="mono">${split.metrics?.avg_reward == null ? "-" : Number(split.metrics.avg_reward).toFixed(4)}</td>
+                          <td class="mono">${split.metrics?.pass1 == null ? "-" : Number(split.metrics.pass1).toFixed(4)}</td>
+                          <td>${resultLink(split)}</td>
+                          <td class="mono">${escapeHtml(split.log_file || "-")}</td>
+                          <td>${escapeHtml(fmtAge(split.mtime ? Date.now() / 1000 - split.mtime : null))}</td>
+                        </tr>
+                        ${
+                          state.expandedSplit === split.key
+                            ? `<tr><td colspan="8">${renderLogPanel(split)}</td></tr>`
+                            : ""
+                        }
+                      `,
+                    )
+                    .join("") || `<tr><td colspan="8"><div class="empty">No split logs</div></td></tr>`
+                }
+              </tbody>
+            </table>
+          </section>
+
+          ${renderResultFilesSection(run)}
+        `;
+
+        content.querySelectorAll(".split-row").forEach((row) => {
+          row.addEventListener("click", () => {
+            const split = row.dataset.split;
+            state.expandedSplit = state.expandedSplit === split ? "" : split;
+            renderContent();
+            if (state.expandedSplit) loadLog();
+          });
+        });
+
+        bindResultEvents(content);
+
+        const refreshLog = document.getElementById("refreshLogBtn");
+        if (refreshLog) refreshLog.addEventListener("click", loadLog);
+        const lines = document.getElementById("logLines");
+        if (lines) {
+          lines.addEventListener("change", () => {
+            state.logLines = Math.max(1, Math.min(5000, Number(lines.value) || 300));
+            loadLog();
+          });
+        }
+      }
+
+      function renderResultFilesSection(run) {
+        const files = resultFilesForRun(run);
+        const pageCount = Math.max(1, Math.ceil(files.length / state.resultFilesPerPage));
+        state.resultFilePage = Math.min(state.resultFilePage, pageCount - 1);
+        const start = state.resultFilePage * state.resultFilesPerPage;
+        const visibleFiles = files.slice(start, start + state.resultFilesPerPage);
+        return `
+          <section class="section">
+            <div class="section-head">
+              <h3>Result Files</h3>
+              <span class="mono">${files.length} files</span>
+            </div>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>file</th>
+                  <th>split</th>
+                  <th>status</th>
+                  <th>samples</th>
+                  <th>avg reward</th>
+                  <th>size</th>
+                  <th>updated</th>
+                  <th>open</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${
+                  visibleFiles
+                    .map(
+                      (fileRow) => `
+                        <tr class="result-row" data-file="${escapeHtml(fileRow.file)}">
+                          <td class="mono">${escapeHtml(fileRow.file)}</td>
+                          <td class="mono">${escapeHtml(fileRow.split)}</td>
+                          <td>${statusBadge(fileRow.status)}</td>
+                          <td class="mono">${fileRow.completed}/${fileRow.expected}</td>
+                          <td class="mono">${fileRow.metrics.avg_reward == null ? "-" : Number(fileRow.metrics.avg_reward).toFixed(4)}</td>
+                          <td class="mono">${escapeHtml(fmtSize(fileRow.size))}</td>
+                          <td>${escapeHtml(fmtAge(fileRow.mtime ? Date.now() / 1000 - fileRow.mtime : null))}</td>
+                          <td><a class="small-link" href="${escapeHtml(trajectoryHref(fileRow.file))}" target="_blank" rel="noopener noreferrer">trajectory</a></td>
+                        </tr>
+                        ${
+                          state.expandedResultFile === fileRow.file
+                            ? `<tr><td colspan="8">${renderResultPanel(fileRow)}</td></tr>`
+                            : ""
+                        }
+                      `,
+                    )
+                    .join("") || `<tr><td colspan="8"><div class="empty">No result files yet</div></td></tr>`
+                }
+              </tbody>
+            </table>
+            ${renderPager("result", state.resultFilePage, pageCount, files.length)}
+          </section>
+        `;
+      }
+
+      function renderPager(kind, page, pageCount, total, file = "") {
+        if (pageCount <= 1) return "";
+        const attrs = file ? ` data-file="${escapeHtml(file)}"` : "";
+        return `
+          <div class="pager">
+            <span>${total} total · page ${page + 1}/${pageCount}</span>
+            <button data-page-kind="${kind}" data-page="${page - 1}"${attrs} ${page <= 0 ? "disabled" : ""}>prev</button>
+            <button data-page-kind="${kind}" data-page="${page + 1}"${attrs} ${page >= pageCount - 1 ? "disabled" : ""}>next</button>
+          </div>
+        `;
+      }
+
+      function renderResultPanel(fileRow) {
+        const file = fileRow.file;
+        const page = state.resultRunPages[file] || 0;
+        const cache = state.resultRuns[file];
+        if (!cache) {
+          queueMicrotask(() => loadResultRuns(file));
+          return `<div class="result-panel"><div class="empty">loading simulations...</div></div>`;
+        }
+        if (cache.loading) {
+          return `<div class="result-panel"><div class="empty">loading simulations...</div></div>`;
+        }
+        if (cache.error) {
+          return `<div class="result-panel"><div class="empty">${escapeHtml(cache.error)}</div></div>`;
+        }
+        const total = cache.total_count || cache.simulation_count || 0;
+        const pageCount = Math.max(1, Math.ceil(total / state.resultRowsPerPage));
+        return `
+          <div class="result-panel">
+            <table class="nested-table">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>reward</th>
+                  <th>task</th>
+                  <th>trial</th>
+                  <th>termination</th>
+                  <th>messages</th>
+                  <th>open</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${
+                  (cache.runs || [])
+                    .map((sim) => renderSimulationRow(file, sim))
+                    .join("") || `<tr><td colspan="7"><div class="empty">No simulations</div></td></tr>`
+                }
+              </tbody>
+            </table>
+            ${renderPager("sim", page, pageCount, total, file)}
+          </div>
+        `;
+      }
+
+      function renderSimulationRow(file, sim) {
+        const key = simulationKey(file, sim.index);
+        const opened = state.expandedSimulation === key;
+        return `
+          <tr class="simulation-row" data-file="${escapeHtml(file)}" data-sim-index="${escapeHtml(sim.index)}">
+            <td class="mono">#${escapeHtml(sim.display_index ?? sim.index)}</td>
+            <td class="mono">${sim.reward == null ? "-" : escapeHtml(sim.reward)}</td>
+            <td class="mono">${escapeHtml(sim.task_id || "-")}</td>
+            <td class="mono">${escapeHtml(sim.trial ?? "-")}</td>
+            <td>${escapeHtml(sim.termination_reason || "-")}</td>
+            <td class="mono">${escapeHtml(sim.message_count ?? "-")}</td>
+            <td><a class="small-link" href="${escapeHtml(trajectoryHref(file, sim.index))}" target="_blank" rel="noopener noreferrer">trajectory</a></td>
+          </tr>
+          ${opened ? `<tr><td colspan="7">${renderSimulationDetail(file, sim.index)}</td></tr>` : ""}
+        `;
+      }
+
+      function renderSimulationDetail(file, simIndex) {
+        const key = simulationKey(file, simIndex);
+        const cache = state.timelines[key];
+        if (!cache) {
+          queueMicrotask(() => loadTimelinePreview(file, simIndex));
+          return `<div class="result-panel"><div class="empty">loading timeline...</div></div>`;
+        }
+        if (cache.loading) {
+          return `<div class="result-panel"><div class="empty">loading timeline...</div></div>`;
+        }
+        if (cache.error) {
+          return `<div class="result-panel"><div class="empty">${escapeHtml(cache.error)}</div></div>`;
+        }
+        const summary = cache.summary || {};
+        return `
+          <div class="result-panel">
+            <div class="mono" style="margin-bottom:10px">
+              task=${escapeHtml(summary.task_id || "-")} · reward=${escapeHtml(summary.reward ?? "-")}
+              · termination=${escapeHtml(summary.termination_reason || "-")}
+              · messages=${escapeHtml(summary.message_count ?? "-")}
+            </div>
+            <div class="timeline-preview">
+              ${(cache.timeline || []).map(renderTimelinePreviewEntry).join("")}
+            </div>
+          </div>
+        `;
+      }
+
+      function renderTimelinePreviewEntry(entry) {
+        const title = `#${entry.seq} · ${entry.kind || "unknown"}${entry.turn_idx == null ? "" : ` · turn ${entry.turn_idx}`}`;
+        const rawBody =
+          entry.content ||
+          entry.reasoning ||
+          entry.repr ||
+          entry.tool_results ||
+          entry.tool_calls ||
+          entry.raw_data ||
+          {};
+        const body = typeof rawBody === "string" ? rawBody : JSON.stringify(rawBody, null, 2);
+        return `
+          <details>
+            <summary>${escapeHtml(title)}</summary>
+            <pre>${escapeHtml(body || "")}</pre>
+          </details>
+        `;
+      }
+
+      function resultLink(split) {
+        if (!split.result_view_file) return `<span class="mono">-</span>`;
+        return `<a href="${escapeHtml(trajectoryHref(split.result_view_file))}" target="_blank" rel="noopener noreferrer">open</a>`;
+      }
+
+      function bindResultEvents(root) {
+        root.querySelectorAll(".result-row").forEach((row) => {
+          row.addEventListener("click", (event) => {
+            if (event.target.closest("a,button")) return;
+            const file = row.dataset.file;
+            state.expandedResultFile = state.expandedResultFile === file ? "" : file;
+            state.expandedSimulation = "";
+            renderContent();
+            if (state.expandedResultFile) loadResultRuns(state.expandedResultFile);
+          });
+        });
+
+        root.querySelectorAll(".simulation-row").forEach((row) => {
+          row.addEventListener("click", (event) => {
+            if (event.target.closest("a,button")) return;
+            const file = row.dataset.file;
+            const simIndex = row.dataset.simIndex;
+            const key = simulationKey(file, simIndex);
+            state.expandedSimulation = state.expandedSimulation === key ? "" : key;
+            renderContent();
+            if (state.expandedSimulation) loadTimelinePreview(file, simIndex);
+          });
+        });
+
+        root.querySelectorAll("[data-page-kind]").forEach((button) => {
+          button.addEventListener("click", () => {
+            if (button.disabled) return;
+            const page = Number(button.dataset.page) || 0;
+            if (button.dataset.pageKind === "result") {
+              state.resultFilePage = page;
+              state.expandedResultFile = "";
+              state.expandedSimulation = "";
+              renderContent();
+              return;
+            }
+            const file = button.dataset.file;
+            state.resultRunPages[file] = page;
+            state.expandedSimulation = "";
+            loadResultRuns(file);
+          });
+        });
+      }
+
+      function simulationKey(file, simIndex) {
+        return `${file}::${simIndex}`;
+      }
+
+      async function loadResultRuns(file) {
+        const page = state.resultRunPages[file] || 0;
+        state.resultRuns[file] = {
+          ...(state.resultRuns[file] || {}),
+          loading: true,
+        };
+        const params = new URLSearchParams({
+          file,
+          offset: String(page * state.resultRowsPerPage),
+          limit: String(state.resultRowsPerPage),
+        });
+        try {
+          const res = await fetch(`/api/simulation-runs?${params.toString()}`);
+          if (!res.ok) throw new Error(await res.text());
+          state.resultRuns[file] = await res.json();
+        } catch (err) {
+          state.resultRuns[file] = { error: err.message || String(err) };
+        }
+        renderContent();
+      }
+
+      async function loadTimelinePreview(file, simIndex) {
+        const key = simulationKey(file, simIndex);
+        state.timelines[key] = {
+          ...(state.timelines[key] || {}),
+          loading: true,
+        };
+        const params = new URLSearchParams({
+          file,
+          sim_index: String(simIndex),
+          include_raw: "false",
+        });
+        try {
+          const res = await fetch(`/api/simulation-timeline?${params.toString()}`);
+          if (!res.ok) throw new Error(await res.text());
+          state.timelines[key] = await res.json();
+        } catch (err) {
+          state.timelines[key] = { error: err.message || String(err) };
+        }
+        renderContent();
+      }
+
+      function renderLogPanel(split) {
+        return `
+          <div class="log-panel">
+            <div class="log-tools">
+              <span class="mono">${escapeHtml(split.log_file || split.label)}</span>
+              <input id="logLines" type="number" min="1" max="5000" value="${state.logLines}" />
+              <button id="refreshLogBtn">refresh</button>
+            </div>
+            <pre id="logText">loading...</pre>
+          </div>
+        `;
+      }
+
+      async function loadLog() {
+        if (!state.selectedRun || !state.expandedSplit) return;
+        const target = document.getElementById("logText");
+        if (!target) return;
+        const params = new URLSearchParams({
+          run_name: state.selectedRun,
+          split: state.expandedSplit,
+          lines: String(state.logLines),
+        });
+        const res = await fetch(`/api/benchmark-log?${params.toString()}`);
+        target.textContent = res.ok ? await res.text() : await res.text();
+      }
+
+      function tickClock() {
+        document.getElementById("clock").textContent = new Date().toLocaleTimeString();
+      }
+
+      document.getElementById("refreshBtn").addEventListener("click", loadRuns);
+      document.getElementById("runFilter").addEventListener("input", renderRuns);
+      document.getElementById("autoBtn").addEventListener("click", () => {
+        state.autoRefresh = !state.autoRefresh;
+        document.getElementById("autoBtn").textContent = state.autoRefresh
+          ? "auto on"
+          : "auto off";
+      });
+
+      setInterval(() => {
+        tickClock();
+        if (state.autoRefresh) loadRuns().catch(console.error);
+      }, 8000);
+
+      tickClock();
+      setInterval(tickClock, 1000);
+      loadRuns().catch((err) => {
+        document.getElementById("content").innerHTML =
+          `<div class="empty">${escapeHtml(err.message)}</div>`;
+      });
+    </script>
+  </body>
+</html>

--- a/src/vita/web/dashboard.html
+++ b/src/vita/web/dashboard.html
@@ -983,7 +983,19 @@
         return `
           <details>
             <summary>${escapeHtml(title)}</summary>
+            ${renderHttpRequest(entry.http_request)}
             <pre>${escapeHtml(body || "")}</pre>
+          </details>
+        `;
+      }
+
+      function renderHttpRequest(request) {
+        if (!request) return "";
+        const label = request.source === "recorded" ? "raw HTTP request" : "reconstructed HTTP request";
+        return `
+          <details>
+            <summary>${escapeHtml(label)}</summary>
+            <pre>${escapeHtml(JSON.stringify(request, null, 2))}</pre>
           </details>
         `;
       }

--- a/src/vita/web/index.html
+++ b/src/vita/web/index.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VitaBench 日志分析</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 0; background: #f6f8fb; color: #1f2937; }
+      .wrap { max-width: 1400px; margin: 0 auto; padding: 16px; }
+      .grid { display: grid; grid-template-columns: 320px 1fr; gap: 16px; }
+      .card { background: #fff; border: 1px solid #e5e7eb; border-radius: 10px; padding: 12px; }
+      h1 { font-size: 20px; margin: 0 0 12px; }
+      h2 { font-size: 15px; margin: 0 0 8px; }
+      .run-item { border: 1px solid #e5e7eb; border-radius: 8px; padding: 8px; margin-bottom: 8px; cursor: pointer; }
+      .run-item.active { border-color: #3b82f6; background: #eff6ff; }
+      label { font-size: 12px; display: block; margin: 8px 0 4px; color: #374151; }
+      input, select { width: 100%; box-sizing: border-box; padding: 8px; border: 1px solid #d1d5db; border-radius: 8px; }
+      button { margin-top: 10px; background: #2563eb; color: #fff; border: none; border-radius: 8px; padding: 8px 12px; cursor: pointer; }
+      .events { max-height: 76vh; overflow: auto; }
+      .event { border-bottom: 1px solid #f1f5f9; padding: 10px 0; }
+      .event-head { font-size: 13px; font-weight: bold; margin-bottom: 6px; }
+      pre { margin: 0; padding: 8px; border-radius: 8px; background: #0b1020; color: #d1d5db; font-size: 12px; overflow: auto; }
+      .muted { color: #6b7280; font-size: 12px; }
+    </style>
+  </head>
+  <body>
+    <div style="background:#0f172a;color:#e2e8f0;padding:10px 20px;display:flex;gap:16px;align-items:center;flex-wrap:wrap">
+      <strong>VitaBench</strong>
+      <span style="opacity:.85">事件日志（data/logs/*.jsonl）</span>
+      <a href="/trajectory" style="color:#93c5fd">完整轨迹（data/simulations/*.json）→</a>
+    </div>
+    <div class="wrap">
+      <h1>VitaBench 日志分析面板</h1>
+      <div class="grid">
+        <div class="card">
+          <h2>Run 列表</h2>
+          <div id="runs"></div>
+        </div>
+        <div class="card">
+          <h2>事件过滤</h2>
+          <div class="muted">可按 task/trial/event_type/关键词过滤，查看完整事件 JSON。</div>
+          <label>Task ID</label>
+          <input id="taskId" placeholder="例如 1" />
+          <label>Trial</label>
+          <input id="trial" type="number" placeholder="例如 0" />
+          <label>Event Type</label>
+          <input id="eventType" placeholder="例如 tool_call_finished" />
+          <label>关键词</label>
+          <input id="q" placeholder="全文搜索 JSON 文本" />
+          <label>限制数量</label>
+          <input id="limit" type="number" value="500" />
+          <button id="searchBtn">查询事件</button>
+          <p class="muted" id="meta"></p>
+          <div class="events" id="events"></div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      let currentRun = null;
+
+      async function loadRuns() {
+        const res = await fetch("/api/runs");
+        const data = await res.json();
+        const runs = document.getElementById("runs");
+        runs.innerHTML = "";
+        for (const run of data.runs) {
+          const div = document.createElement("div");
+          div.className = "run-item" + (currentRun === run.run_id ? " active" : "");
+          div.innerHTML = `
+            <div><strong>${run.run_id}</strong></div>
+            <div class="muted">events: ${run.total_events}</div>
+            <div class="muted">simulations: ${run.simulations.length}</div>
+          `;
+          div.onclick = () => {
+            currentRun = run.run_id;
+            loadRuns();
+            loadEvents();
+          };
+          runs.appendChild(div);
+        }
+      }
+
+      async function loadEvents() {
+        if (!currentRun) return;
+        const taskId = document.getElementById("taskId").value.trim();
+        const trial = document.getElementById("trial").value.trim();
+        const eventType = document.getElementById("eventType").value.trim();
+        const q = document.getElementById("q").value.trim();
+        const limit = document.getElementById("limit").value.trim() || "500";
+
+        const params = new URLSearchParams({ run_id: currentRun, limit });
+        if (taskId) params.append("task_id", taskId);
+        if (trial) params.append("trial", trial);
+        if (eventType) params.append("event_type", eventType);
+        if (q) params.append("q", q);
+
+        const res = await fetch(`/api/events?${params.toString()}`);
+        const data = await res.json();
+        document.getElementById("meta").textContent =
+          `当前 run: ${currentRun} | 命中 ${data.count} 条` + (data.truncated ? "（已截断）" : "");
+
+        const events = document.getElementById("events");
+        events.innerHTML = "";
+        for (const event of data.events) {
+          const div = document.createElement("div");
+          div.className = "event";
+          div.innerHTML = `
+            <div class="event-head">${event.timestamp || ""} | ${event.event_type || ""} | task=${event.task_id ?? "-"} | trial=${event.trial ?? "-"}</div>
+            <pre>${JSON.stringify(event, null, 2)}</pre>
+          `;
+          events.appendChild(div);
+        }
+      }
+
+      document.getElementById("searchBtn").onclick = loadEvents;
+      loadRuns();
+    </script>
+  </body>
+</html>

--- a/src/vita/web/tools.html
+++ b/src/vita/web/tools.html
@@ -1,0 +1,240 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VitaBench 工具调试台</title>
+    <style>
+      body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "PingFang SC", sans-serif; margin: 0; background: #f5f7fb; color: #1e293b; }
+      .top { background: #0f172a; color: #e2e8f0; padding: 10px 16px; display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+      .top a { color: #93c5fd; text-decoration: none; }
+      .wrap { max-width: 1080px; margin: 0 auto; padding: 16px; }
+      .card { background: #fff; border: 1px solid #e2e8f0; border-radius: 10px; padding: 12px; margin-bottom: 12px; }
+      .row { display: flex; gap: 10px; flex-wrap: wrap; }
+      .field { flex: 1; min-width: 220px; }
+      label { display: block; font-size: 12px; color: #64748b; margin-bottom: 4px; }
+      select, button, input { width: 100%; box-sizing: border-box; padding: 8px 10px; border: 1px solid #cbd5e1; border-radius: 8px; }
+      button { background: #2563eb; color: #fff; border: none; cursor: pointer; }
+      button.secondary { background: #334155; }
+      pre { margin: 0; padding: 10px; background: #0b1020; color: #e2e8f0; border-radius: 8px; font-size: 12px; white-space: pre-wrap; word-break: break-word; max-height: 420px; overflow: auto; }
+      .muted { font-size: 12px; color: #64748b; }
+    </style>
+  </head>
+  <body>
+    <div class="top">
+      <strong>VitaBench</strong>
+      <a href="/">完整轨迹</a>
+      <span>工具调试台（独立窗口）</span>
+    </div>
+    <div class="wrap">
+      <div class="card">
+        <h2 style="margin:0 0 8px">选择仿真上下文</h2>
+        <div class="row">
+          <div class="field">
+            <label>结果文件过滤</label>
+            <input id="fileFilter" placeholder="例如 merged / minimax / instore" />
+          </div>
+          <div class="field">
+            <label>结果文件</label>
+            <select id="fileSelect"></select>
+          </div>
+          <div class="field">
+            <label>simulation</label>
+            <select id="simSelect"></select>
+          </div>
+          <div class="field" style="flex:0">
+            <label>&nbsp;</label>
+            <button id="loadToolsBtn">加载工具</button>
+          </div>
+        </div>
+        <p class="muted" id="ctxNote"></p>
+      </div>
+
+      <div class="card">
+        <h2 style="margin:0 0 8px">工具详情与调用</h2>
+        <div class="row">
+          <div class="field">
+            <label>工具</label>
+            <select id="toolSelect"></select>
+          </div>
+          <div class="field" style="flex:0">
+            <label>&nbsp;</label>
+            <button class="secondary" id="refreshBtn">刷新</button>
+          </div>
+        </div>
+        <details open style="margin-top:8px">
+          <summary><strong>工具详细信息 / schema</strong></summary>
+          <pre id="toolMeta"></pre>
+        </details>
+        <label style="margin-top:10px">调用参数（JSON）</label>
+        <pre id="argsEditor" contenteditable="true" style="min-height:120px"></pre>
+        <div class="row" style="margin-top:8px">
+          <div class="field" style="flex:0">
+            <button id="invokeBtn">调用工具</button>
+          </div>
+        </div>
+        <details open style="margin-top:8px">
+          <summary><strong>调用返回</strong></summary>
+          <pre id="invokeResult"></pre>
+        </details>
+      </div>
+    </div>
+
+    <script>
+      let currentTools = [];
+      let allFiles = [];
+
+      function esc(s) {
+        if (s == null) return "";
+        return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+      }
+
+      function outcomeLabel(reward) {
+        if (reward == null) return "未评估";
+        return Number(reward) === 1 ? "正确" : "错误";
+      }
+
+      function renderFileOptions(filterText = "") {
+        const sel = document.getElementById("fileSelect");
+        const prev = sel.value;
+        const q = filterText.trim().toLowerCase();
+        const files = q
+          ? allFiles.filter((f) => ((f.path || f.name || "").toLowerCase().includes(q)))
+          : allFiles;
+        sel.innerHTML = "";
+        if (!files.length) {
+          const o = document.createElement("option");
+          o.value = "";
+          o.textContent = allFiles.length ? "（没有匹配的结果文件）" : "（暂无 simulations/**/*.json）";
+          sel.appendChild(o);
+          return;
+        }
+        for (const f of files) {
+          const o = document.createElement("option");
+          const path = f.path || f.name;
+          o.value = path;
+          o.textContent = `${path} · ${Math.round(f.size / 1024)} KB`;
+          sel.appendChild(o);
+        }
+        if (prev && files.some((f) => (f.path || f.name) === prev)) {
+          sel.value = prev;
+        }
+      }
+
+      async function loadFiles() {
+        const res = await fetch("/api/simulations");
+        const data = await res.json();
+        allFiles = data.files || [];
+        renderFileOptions(document.getElementById("fileFilter").value);
+      }
+
+      async function loadRuns() {
+        const file = document.getElementById("fileSelect").value;
+        if (!file) return;
+        const res = await fetch("/api/simulation-runs?" + new URLSearchParams({ file }));
+        const data = await res.json();
+        const sel = document.getElementById("simSelect");
+        sel.innerHTML = "";
+        for (const r of data.runs || []) {
+          const o = document.createElement("option");
+          o.value = String(r.index);
+          o.textContent = `#${r.index} ${outcomeLabel(r.reward)} reward=${r.reward ?? "-"} task=${r.task_id} trial=${r.trial ?? "-"} · ${r.message_count} msgs`;
+          sel.appendChild(o);
+        }
+      }
+
+      function setToolMeta(tool) {
+        document.getElementById("toolMeta").textContent = tool ? JSON.stringify(tool, null, 2) : "";
+      }
+
+      function setArgsTemplate(tool) {
+        const props = (tool?.openai_schema?.function?.parameters?.properties) || {};
+        const args = {};
+        for (const k of Object.keys(props)) {
+          const t = props[k]?.type;
+          if (t === "integer" || t === "number") args[k] = 0;
+          else if (t === "boolean") args[k] = false;
+          else if (t === "array") args[k] = [];
+          else if (t === "object") args[k] = {};
+          else args[k] = "";
+        }
+        document.getElementById("argsEditor").textContent = JSON.stringify(args, null, 2);
+      }
+
+      async function loadTools() {
+        const file = document.getElementById("fileSelect").value;
+        const simIndex = parseInt(document.getElementById("simSelect").value || "0", 10);
+        if (!file) return;
+        const res = await fetch("/api/simulation-tools?" + new URLSearchParams({ file, sim_index: String(simIndex) }));
+        if (!res.ok) {
+          document.getElementById("ctxNote").textContent = await res.text();
+          return;
+        }
+        const data = await res.json();
+        document.getElementById("ctxNote").textContent = `task=${data.task_id} domain=${data.domain}。${data.note || ""}`;
+        currentTools = data.tools || [];
+        const sel = document.getElementById("toolSelect");
+        sel.innerHTML = "";
+        for (const t of currentTools) {
+          const o = document.createElement("option");
+          o.value = t.name;
+          o.textContent = t.name;
+          sel.appendChild(o);
+        }
+        if (currentTools.length > 0) {
+          setToolMeta(currentTools[0]);
+          setArgsTemplate(currentTools[0]);
+        } else {
+          setToolMeta(null);
+          document.getElementById("argsEditor").textContent = "{}";
+        }
+      }
+
+      async function invokeTool() {
+        const file = document.getElementById("fileSelect").value;
+        const simIndex = parseInt(document.getElementById("simSelect").value || "0", 10);
+        const toolName = document.getElementById("toolSelect").value;
+        let args = {};
+        try {
+          args = JSON.parse(document.getElementById("argsEditor").textContent || "{}");
+        } catch (e) {
+          document.getElementById("invokeResult").textContent = "参数 JSON 解析失败: " + e;
+          return;
+        }
+        const res = await fetch("/api/simulation-tool-invoke", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            file,
+            sim_index: simIndex,
+            tool_name: toolName,
+            arguments: args,
+          }),
+        });
+        const txt = await res.text();
+        try {
+          document.getElementById("invokeResult").textContent = JSON.stringify(JSON.parse(txt), null, 2);
+        } catch (_) {
+          document.getElementById("invokeResult").textContent = txt;
+        }
+      }
+
+      document.getElementById("fileSelect").onchange = loadRuns;
+      document.getElementById("fileFilter").oninput = () => {
+        renderFileOptions(document.getElementById("fileFilter").value);
+        loadRuns().then(loadTools);
+      };
+      document.getElementById("simSelect").onchange = loadTools;
+      document.getElementById("loadToolsBtn").onclick = loadTools;
+      document.getElementById("refreshBtn").onclick = loadTools;
+      document.getElementById("invokeBtn").onclick = invokeTool;
+      document.getElementById("toolSelect").onchange = () => {
+        const t = currentTools.find((x) => x.name === document.getElementById("toolSelect").value);
+        setToolMeta(t || null);
+        setArgsTemplate(t || null);
+      };
+
+      loadFiles().then(loadRuns).then(loadTools);
+    </script>
+  </body>
+</html>

--- a/src/vita/web/trajectory.html
+++ b/src/vita/web/trajectory.html
@@ -367,6 +367,17 @@
         return html;
       }
 
+      function renderHttpRequest(request) {
+        if (!request) return "";
+        const label = request.source === "recorded" ? "原始 HTTP 请求" : "重建 HTTP 请求";
+        return (
+          "<details><summary><strong>" +
+          esc(label) +
+          "</strong></summary><pre>" +
+          esc(JSON.stringify(request, null, 2)) +
+          "</pre></details>"
+        );
+      }
 
       function buildUserProfileHtml(p) {
         if (!p) return "";
@@ -522,6 +533,7 @@
               esc(JSON.stringify(e.raw_data, null, 2)) +
               "</pre></details>";
           }
+          body += renderHttpRequest(e.http_request);
         } else if (kind === "assistant") {
           if (e.assistant_received_context && e.assistant_received_context.length) {
             body +=
@@ -552,6 +564,7 @@
               esc(JSON.stringify(e.raw_data, null, 2)) +
               "</pre></details>";
           }
+          body += renderHttpRequest(e.http_request);
         } else if (kind === "tool") {
           body =
             '<div class="badge">call_id: ' +

--- a/src/vita/web/trajectory.html
+++ b/src/vita/web/trajectory.html
@@ -379,6 +379,19 @@
         );
       }
 
+      function renderHttpResponse(response) {
+        if (!response) return "";
+        const label =
+          response.source === "saved_choice_only" ? "已保存的 assistant/user 返回" : "原始 HTTP 响应";
+        return (
+          "<details><summary><strong>" +
+          esc(label) +
+          "</strong></summary><pre>" +
+          esc(JSON.stringify(response, null, 2)) +
+          "</pre></details>"
+        );
+      }
+
       function buildUserProfileHtml(p) {
         if (!p) return "";
         let h =
@@ -534,6 +547,7 @@
               "</pre></details>";
           }
           body += renderHttpRequest(e.http_request);
+          body += renderHttpResponse(e.http_response);
         } else if (kind === "assistant") {
           if (e.assistant_received_context && e.assistant_received_context.length) {
             body +=
@@ -565,6 +579,7 @@
               "</pre></details>";
           }
           body += renderHttpRequest(e.http_request);
+          body += renderHttpResponse(e.http_response);
         } else if (kind === "tool") {
           body =
             '<div class="badge">call_id: ' +

--- a/src/vita/web/trajectory.html
+++ b/src/vita/web/trajectory.html
@@ -1,0 +1,667 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VitaBench 完整轨迹</title>
+    <style>
+      :root {
+        --bg: #f0f4f8;
+        --card: #fff;
+        --border: #e2e8f0;
+        --text: #1e293b;
+        --muted: #64748b;
+        --user: #1d4ed8;
+        --assistant: #6d28d9;
+        --tool: #047857;
+        --system: #475569;
+        --reason: #0f766e;
+        --err: #b91c1c;
+      }
+      body {
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "PingFang SC", sans-serif;
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+      }
+      .topnav {
+        background: #0f172a;
+        color: #e2e8f0;
+        padding: 10px 20px;
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+      .topnav a {
+        color: #93c5fd;
+        text-decoration: none;
+      }
+      .topnav a:hover {
+        text-decoration: underline;
+      }
+      .wrap {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 16px;
+      }
+      h1 {
+        font-size: 1.25rem;
+        margin: 0 0 12px;
+      }
+      .row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: flex-end;
+        margin-bottom: 16px;
+      }
+      .field {
+        flex: 1;
+        min-width: 200px;
+      }
+      label {
+        display: block;
+        font-size: 12px;
+        color: var(--muted);
+        margin-bottom: 4px;
+      }
+      select,
+      input,
+      button {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 8px 10px;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        font-size: 14px;
+      }
+      button {
+        background: #2563eb;
+        color: #fff;
+        border: none;
+        cursor: pointer;
+        max-width: 140px;
+      }
+      button.secondary {
+        background: #334155;
+      }
+      .summary {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 12px 14px;
+        margin-bottom: 16px;
+        font-size: 13px;
+      }
+      .summary code {
+        background: #f1f5f9;
+        padding: 1px 6px;
+        border-radius: 4px;
+      }
+      .timeline {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .msg {
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        background: var(--card);
+        overflow: hidden;
+      }
+      .msg-head {
+        padding: 8px 12px;
+        font-weight: 600;
+        font-size: 13px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .msg.user .msg-head {
+        background: #eff6ff;
+        color: var(--user);
+      }
+      .msg.assistant .msg-head {
+        background: #f5f3ff;
+        color: var(--assistant);
+      }
+      .msg.tool .msg-head,
+      .msg.multi_tool .msg-head {
+        background: #ecfdf5;
+        color: var(--tool);
+      }
+      .msg.system .msg-head {
+        background: #f1f5f9;
+        color: var(--system);
+      }
+      .msg-body {
+        padding: 10px 12px 12px;
+        font-size: 13px;
+      }
+      .badge {
+        font-size: 11px;
+        font-weight: 500;
+        color: var(--muted);
+      }
+      pre {
+        margin: 0;
+        padding: 10px;
+        background: #0b1020;
+        color: #e2e8f0;
+        border-radius: 8px;
+        font-size: 12px;
+        line-height: 1.45;
+        overflow: auto;
+        max-height: 420px;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      details {
+        margin-top: 8px;
+        border: 1px dashed var(--border);
+        border-radius: 8px;
+        padding: 6px 8px;
+        background: #fafafa;
+      }
+      details summary {
+        cursor: pointer;
+        font-size: 12px;
+        color: var(--muted);
+        user-select: none;
+      }
+      .reasoning-label {
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--reason);
+        margin-bottom: 6px;
+      }
+      .reasoning-label-user {
+        font-size: 12px;
+        font-weight: 600;
+        color: #1e40af;
+        margin-bottom: 6px;
+      }
+      pre.reasoning-user {
+        background: #1e3a5f;
+        color: #dbeafe;
+      }
+      .profile-card {
+        border-left: 4px solid #2563eb;
+        margin-bottom: 14px;
+      }
+      .profile-card h2 {
+        font-size: 16px;
+        margin: 0 0 8px;
+      }
+      .tool-panel h2 {
+        font-size: 16px;
+        margin: 0 0 8px;
+      }
+      .tool-panel .row {
+        margin-bottom: 8px;
+      }
+      .empty {
+        color: var(--muted);
+        padding: 24px;
+        text-align: center;
+      }
+      .err {
+        color: var(--err);
+        font-weight: 600;
+      }
+      .tc-arg {
+        margin-top: 6px;
+      }
+    </style>
+  </head>
+  <body>
+    <nav class="topnav">
+      <strong>VitaBench</strong>
+      <span>完整轨迹（simulations/**/*.json）</span>
+      <span style="opacity: 0.7">|</span>
+      <a href="/toolbox" target="_blank" rel="noopener noreferrer">工具调试台（独立窗口）</a>
+    </nav>
+    <div class="wrap">
+      <h1>按时间顺序查看：用户 · 模型（含思维链）· 工具</h1>
+      <p style="color: var(--muted); font-size: 13px; margin: 0 0 12px">
+        数据来自 <code>data/simulations/</code> 中保存的仿真结果，包含子目录中的 chunk/merged 结果。
+      </p>
+      <div class="row">
+        <div class="field">
+          <label>结果文件过滤</label>
+          <input id="fileFilter" placeholder="例如 merged / minimax / instore" />
+        </div>
+        <div class="field">
+          <label>结果文件</label>
+          <select id="fileSelect"></select>
+        </div>
+        <div class="field">
+          <label>本次 batch 中的第几条 simulation</label>
+          <select id="simSelect"></select>
+        </div>
+        <div class="field" style="flex: 0">
+          <label>&nbsp;</label>
+          <button id="loadBtn">加载轨迹</button>
+        </div>
+        <div class="field" style="flex: 0">
+          <label>&nbsp;</label>
+          <button class="secondary" id="toggleRaw" type="button" title="关闭可略减轻负载">
+            含 raw_data: 开
+          </button>
+        </div>
+      </div>
+      <div class="summary profile-card" id="userProfile" style="display: none"></div>
+      <div class="summary profile-card" id="evaluationResult" style="display: none"></div>
+      <div class="summary" id="summary" style="display: none"></div>
+      <div class="timeline" id="timeline"></div>
+      <p class="empty" id="placeholder">请选择结果文件并点击「加载轨迹」。</p>
+    </div>
+
+    <script>
+      let includeRaw = true;
+      let allFiles = [];
+      const initialParams = new URLSearchParams(location.search);
+      const initialFile = initialParams.get("file") || "";
+      const initialSimIndex = initialParams.get("sim_index") || "";
+
+      function renderFileOptions(filterText = "") {
+        const sel = document.getElementById("fileSelect");
+        const prev = sel.value;
+        const q = filterText.trim().toLowerCase();
+        let files = q
+          ? allFiles.filter((f) => ((f.path || f.name || "").toLowerCase().includes(q)))
+          : allFiles;
+        if (initialFile && !files.some((f) => (f.path || f.name) === initialFile)) {
+          files = [{ path: initialFile, name: initialFile, size: 0 }, ...files];
+        }
+        sel.innerHTML = "";
+        if (!files.length) {
+          const o = document.createElement("option");
+          o.value = "";
+          o.textContent = allFiles.length ? "（没有匹配的结果文件）" : "（暂无 simulations/**/*.json）";
+          sel.appendChild(o);
+          return;
+        }
+        for (const f of files) {
+          const o = document.createElement("option");
+          const path = f.path || f.name;
+          o.value = path;
+          o.textContent = path + "  ·  " + Math.round(f.size / 1024) + " KB";
+          sel.appendChild(o);
+        }
+        if (prev && files.some((f) => (f.path || f.name) === prev)) {
+          sel.value = prev;
+        } else if (initialFile && files.some((f) => (f.path || f.name) === initialFile)) {
+          sel.value = initialFile;
+        }
+      }
+
+      async function loadFileList() {
+        const res = await fetch("/api/simulations");
+        const data = await res.json();
+        allFiles = data.files || [];
+        renderFileOptions(document.getElementById("fileFilter").value);
+        if (initialFile) {
+          document.getElementById("fileSelect").value = initialFile;
+        }
+      }
+
+      async function loadRunOptions() {
+        const file = document.getElementById("fileSelect").value;
+        const simSel = document.getElementById("simSelect");
+        simSel.innerHTML = "";
+        if (!file) return;
+        const res = await fetch("/api/simulation-runs?" + new URLSearchParams({ file }));
+        const data = await res.json();
+        for (const r of data.runs) {
+          const o = document.createElement("option");
+          o.value = String(r.index);
+          o.textContent =
+            "#" +
+            (r.display_index ?? r.index) +
+            "  " +
+            outcomeLabel(r.reward) +
+            "  reward=" +
+            (r.reward ?? "-") +
+            "  task=" +
+            r.task_id +
+            "  trial=" +
+            (r.trial ?? "-") +
+            "  ·  " +
+            (r.termination_reason || "") +
+            "  ·  " +
+            r.message_count +
+            " msgs";
+          simSel.appendChild(o);
+        }
+        if (initialSimIndex && [...simSel.options].some((o) => o.value === initialSimIndex)) {
+          simSel.value = initialSimIndex;
+        }
+      }
+
+      function esc(s) {
+        if (s == null) return "";
+        return String(s)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+      }
+
+      function outcomeLabel(reward) {
+        if (reward == null) return "未评估";
+        return Number(reward) === 1 ? "正确" : "错误";
+      }
+
+      function renderToolCalls(tcs) {
+        if (!tcs || !tcs.length) return "";
+        let html = '<div class="tc-arg"><strong>工具调用</strong></div>';
+        for (const tc of tcs) {
+          html +=
+            '<pre style="margin-top:6px">' +
+            esc(JSON.stringify(tc, null, 2)) +
+            "</pre>";
+        }
+        return html;
+      }
+
+
+      function buildUserProfileHtml(p) {
+        if (!p) return "";
+        let h =
+          '<h2>User Simulator 角色设定</h2>' +
+          '<p class="muted" style="margin:0 0 12px;font-size:12px;line-height:1.5">' +
+          "数据来自保存的 <code>results.json</code>：<code>info.user_info</code>（全局说明模板 + 所用模型）以及" +
+          " 当前 <code>task</code> 的 <code>user_scenario</code>、<code>instructions</code>。" +
+          " 下方「实际送入 User LLM 的完整 system」与运行时 <code>UserSimulator.system_prompt</code> 一致（" +
+          "<code>str(user_profile)</code> + <code>instructions</code> 填入模板）。</p>";
+        if (p.note) {
+          h += '<p class="err" style="margin:0 0 8px">' + esc(p.note) + "</p>";
+        }
+        h +=
+          '<div class="badge" style="margin-bottom:10px">implementation=' +
+          esc(p.implementation || "") +
+          " · llm=" +
+          esc(p.llm || "") +
+          (p.domain ? " · domain=" + esc(p.domain) : "") +
+          "</div>";
+        if (p.user_scenario) {
+          h +=
+            '<details open style="margin-top:10px"><summary><strong>user_scenario（人设 / 情境）</strong></summary><pre>' +
+            esc(JSON.stringify(p.user_scenario, null, 2)) +
+            "</pre></details>";
+        }
+        if (p.instructions != null && p.instructions !== "") {
+          h +=
+            '<details open style="margin-top:10px"><summary><strong>instructions（本任务要通过对话传达给智能体的指令）</strong></summary><pre>' +
+            esc(p.instructions) +
+            "</pre></details>";
+        }
+        if (p.persona_runtime_string != null) {
+          h +=
+            '<details style="margin-top:10px"><summary><strong>模板中的 {persona} 实参（与代码中 str(user_profile) 一致）</strong></summary><pre>' +
+            esc(p.persona_runtime_string) +
+            "</pre></details>";
+        }
+        if (p.llm_args) {
+          h +=
+            '<details style="margin-top:10px"><summary><strong>User LLM 调用参数（敏感 HTTP 头已脱敏）</strong></summary><pre>' +
+            esc(JSON.stringify(p.llm_args, null, 2)) +
+            "</pre></details>";
+        }
+        if (p.global_simulation_guidelines_template) {
+          h +=
+            '<details style="margin-top:10px"><summary><strong>全局用户模拟器说明模板（含 {persona}、{instructions} 占位符）</strong></summary><pre style="max-height:360px">' +
+            esc(p.global_simulation_guidelines_template) +
+            "</pre></details>";
+        }
+        if (p.rendered_system_prompt_error) {
+          h +=
+            '<p class="err" style="margin-top:10px">渲染系统提示失败：' +
+            esc(p.rendered_system_prompt_error) +
+            "</p>";
+        }
+        if (p.rendered_user_system_prompt) {
+          h +=
+            '<details open style="margin-top:10px"><summary><strong>实际送入 User LLM 的完整 system 内容</strong></summary><pre style="max-height:560px">' +
+            esc(p.rendered_user_system_prompt) +
+            "</pre></details>";
+        }
+        return h;
+      }
+
+      function buildEvaluationHtml(ev) {
+        if (!ev) return "";
+        const rubrics = Array.isArray(ev.nl_rubrics) ? ev.nl_rubrics : [];
+        const metCount = rubrics.filter((x) => x && x.met === true).length;
+        let h =
+          '<h2>最终评估结果（Evaluator）</h2>' +
+          '<div class="badge" style="margin-bottom:10px">reward=' +
+          esc(ev.reward) +
+          " · rubrics_met=" +
+          esc(`${metCount}/${rubrics.length}`) +
+          "</div>";
+
+        if (ev.reward_breakdown) {
+          h +=
+            '<details open style="margin-top:8px"><summary><strong>Reward Breakdown</strong></summary><pre>' +
+            esc(JSON.stringify(ev.reward_breakdown, null, 2)) +
+            "</pre></details>";
+        }
+
+        if (rubrics.length > 0) {
+          h +=
+            '<details open style="margin-top:8px"><summary><strong>NL Rubrics 判定明细</strong></summary><pre>' +
+            esc(JSON.stringify(rubrics, null, 2)) +
+            "</pre></details>";
+        }
+
+        if (ev.info) {
+          h +=
+            '<details style="margin-top:8px"><summary><strong>Evaluator Additional Info</strong></summary><pre>' +
+            esc(JSON.stringify(ev.info, null, 2)) +
+            "</pre></details>";
+        }
+
+        if (ev.window_evaluations) {
+          h +=
+            '<details style="margin-top:8px"><summary><strong>Sliding Window Evaluations（较大，默认折叠）</strong></summary><pre style="max-height:560px">' +
+            esc(JSON.stringify(ev.window_evaluations, null, 2)) +
+            "</pre></details>";
+        }
+
+        return h;
+      }
+
+      function renderEntry(e) {
+        const kind = e.kind || "unknown";
+        const headLeft =
+          "#" +
+          e.seq +
+          " · " +
+          (kind === "multi_tool" ? "工具（多条）" : kind) +
+          (e.turn_idx != null ? " · turn " + e.turn_idx : "") +
+          (e.timestamp ? " · " + e.timestamp : "");
+        let body = "";
+
+        if (kind === "system") {
+          body = "<pre>" + esc(e.content || "") + "</pre>";
+        } else if (kind === "user") {
+          body = "";
+          if (e.user_received_context && e.user_received_context.length) {
+            body +=
+              '<details><summary><strong>本轮 user 接收到的信息（按顺序重建，默认折叠）</strong></summary><pre>' +
+              esc(JSON.stringify(e.user_received_context, null, 2)) +
+              "</pre></details>";
+          }
+          if (e.reasoning) {
+            body +=
+              '<div class="reasoning-label-user">用户思维链（User Simulator / reasoning）</div><pre class="reasoning-user">' +
+              esc(e.reasoning) +
+              "</pre>";
+          }
+          if (e.content) {
+            body +=
+              '<div style="margin-top:8px"><strong>用户对外发言</strong></div><pre>' +
+              esc(e.content) +
+              "</pre>";
+          }
+          body += renderToolCalls(e.tool_calls);
+          if (e.usage)
+            body +=
+              '<div class="badge" style="margin-top:6px">usage: ' +
+              esc(JSON.stringify(e.usage)) +
+              "</div>";
+          if (e.cost != null)
+            body += '<div class="badge">cost: ' + esc(String(e.cost)) + "</div>";
+          if (e.raw_data && includeRaw) {
+            body +=
+              "<details><summary>raw_data（原始）</summary><pre>" +
+              esc(JSON.stringify(e.raw_data, null, 2)) +
+              "</pre></details>";
+          }
+        } else if (kind === "assistant") {
+          if (e.assistant_received_context && e.assistant_received_context.length) {
+            body +=
+              '<details><summary><strong>本轮 assistant 接收到的信息（按顺序重建，默认折叠）</strong></summary><pre>' +
+              esc(JSON.stringify(e.assistant_received_context, null, 2)) +
+              "</pre></details>";
+          }
+          if (e.reasoning) {
+            body +=
+              '<div class="reasoning-label">助手思维链（Agent LLM / reasoning）</div><pre style="background:#134e4a;color:#ccfbf1">' +
+              esc(e.reasoning) +
+              "</pre>";
+          }
+          if (e.content) {
+            body += '<div style="margin-top:8px"><strong>助手对外发言</strong></div><pre>' + esc(e.content) + "</pre>";
+          }
+          body += renderToolCalls(e.tool_calls);
+          if (e.usage)
+            body +=
+              '<div class="badge" style="margin-top:6px">usage: ' +
+              esc(JSON.stringify(e.usage)) +
+              "</div>";
+          if (e.cost != null)
+            body += '<div class="badge">cost: ' + esc(String(e.cost)) + "</div>";
+          if (e.raw_data && includeRaw) {
+            body +=
+              "<details><summary>raw_data（含接口完整字段）</summary><pre>" +
+              esc(JSON.stringify(e.raw_data, null, 2)) +
+              "</pre></details>";
+          }
+        } else if (kind === "tool") {
+          body =
+            '<div class="badge">call_id: ' +
+            esc(e.tool_call_id) +
+            " · requestor: " +
+            esc(e.requestor) +
+            "</div>";
+          if (e.error) body += '<div class="err" style="margin-top:6px">工具执行报错</div>';
+          body += "<pre style=\"margin-top:8px\">" + esc(e.content || "") + "</pre>";
+        } else if (kind === "multi_tool") {
+          for (const t of e.tool_results || []) {
+            body +=
+              '<div style="margin-top:8px;padding:8px;border:1px solid var(--border);border-radius:8px">';
+            body +=
+              '<div class="badge">' +
+              esc(t.tool_name) +
+              " · " +
+              esc(t.tool_call_id) +
+              "</div>";
+            if (t.error) body += '<div class="err">error</div>';
+            body += "<pre style=\"margin-top:6px\">" + esc(t.content || "") + "</pre></div>";
+          }
+        } else {
+          body = "<pre>" + esc(e.repr || JSON.stringify(e, null, 2)) + "</pre>";
+        }
+
+        return (
+          '<div class="msg ' +
+          (kind === "multi_tool" ? "multi_tool" : kind) +
+          '">' +
+          '<div class="msg-head"><span>' +
+          esc(headLeft) +
+          '</span><span class="badge">' +
+          esc(e.role || "") +
+          "</span></div>" +
+          '<div class="msg-body">' +
+          body +
+          "</div></div>"
+        );
+      }
+
+      async function loadTimeline() {
+        const file = document.getElementById("fileSelect").value;
+        const simIndex = parseInt(document.getElementById("simSelect").value || "0", 10);
+        if (!file) return;
+        const params = new URLSearchParams({
+          file,
+          sim_index: String(simIndex),
+          include_raw: includeRaw ? "true" : "false",
+        });
+        const res = await fetch("/api/simulation-timeline?" + params.toString());
+        if (!res.ok) {
+          alert(await res.text());
+          return;
+        }
+        const data = await res.json();
+        document.getElementById("placeholder").style.display = "none";
+        const profEl = document.getElementById("userProfile");
+        if (data.user_simulator_profile) {
+          profEl.style.display = "block";
+          profEl.innerHTML = buildUserProfileHtml(data.user_simulator_profile);
+        } else {
+          profEl.style.display = "none";
+          profEl.innerHTML = "";
+        }
+        const evalEl = document.getElementById("evaluationResult");
+        if (data.evaluation_result) {
+          evalEl.style.display = "block";
+          evalEl.innerHTML = buildEvaluationHtml(data.evaluation_result);
+        } else {
+          evalEl.style.display = "none";
+          evalEl.innerHTML = "";
+        }
+        const s = data.summary;
+        const sumEl = document.getElementById("summary");
+        sumEl.style.display = "block";
+        sumEl.innerHTML =
+          "<strong>摘要</strong> task_id=<code>" +
+          esc(s.task_id) +
+          "</code> trial=<code>" +
+          esc(s.trial) +
+          "</code> termination=<code>" +
+          esc(s.termination_reason) +
+          "</code> duration=<code>" +
+          esc(s.duration) +
+          "s</code> reward=<code>" +
+          esc(s.reward) +
+          "</code> messages=<code>" +
+          esc(s.message_count) +
+          "</code>";
+        const tl = document.getElementById("timeline");
+        tl.innerHTML = (data.timeline || []).map(renderEntry).join("");
+      }
+
+      document.getElementById("loadBtn").onclick = loadTimeline;
+      document.getElementById("toggleRaw").onclick = () => {
+        includeRaw = !includeRaw;
+        document.getElementById("toggleRaw").textContent = "含 raw_data: " + (includeRaw ? "开" : "关");
+      };
+      document.getElementById("fileSelect").onchange = loadRunOptions;
+      document.getElementById("fileFilter").oninput = () => {
+        renderFileOptions(document.getElementById("fileFilter").value);
+        loadRunOptions();
+      };
+
+      loadFileList()
+        .then(loadRunOptions)
+        .then(() => {
+          if (initialFile) loadTimeline();
+        });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add a FastAPI-backed benchmark dashboard for run and split progress.
- Add configurable dashboard data sources with `--logs-dir` and `--simulations-dir`.
- Add split log viewing plus result-file browsing with paginated simulation expansion.
- Add one-click `non-full reward` filtering for simulations whose reward is not full.
- Add full assistant/user LLM HTTP exchange visibility in expanded dashboard and trajectory traces.
- Record redacted `_http_request` and `_http_response` snapshots for new LLM calls; reconstruct request views and show saved response choices for older Results files.
- Add trajectory, event, and tool viewer pages used by the dashboard.
- Add CLI entries: `vita board` and `vita log-view`.

## Testing
- `python3 -m compileall src/vita/cli.py src/vita/scripts/log_viewer.py`
- `python3 -m ruff check src/vita/cli.py src/vita/scripts/log_viewer.py`
- `PYTHONPATH=src python3 -m vita.cli board --help`
- `TestClient(create_app(simulations_dir=...)).get("/api/simulation-runs", ...)` works for both simulations root and benchmark_runs root
- `python3 -m compileall src/vita/utils/simulation_timeline.py src/vita/utils/llm_utils.py`
- `python3 -m ruff check src/vita/utils/simulation_timeline.py src/vita/utils/llm_utils.py`
- `node --check` on extracted dashboard and trajectory scripts
- `TestClient(create_app()).get("/api/simulation-timeline", ...)` returns HTTP request and response entries
- `TestClient(create_app()).get("/api/simulation-runs", reward_filter="non_full")` returns only non-full reward rows
<sub>✨ Presented to you with <a href=" ">Mind Lab</a > — A Lab for Experiential Intelligence.</sub>